### PR TITLE
Am243x ThreadX Examples Fix

### DIFF
--- a/examples/netxduo/enet_netxduo_cpsw_mac/am243x-evm/r5fss0-0_threadx/example.syscfg
+++ b/examples/netxduo/enet_netxduo_cpsw_mac/am243x-evm/r5fss0-0_threadx/example.syscfg
@@ -296,6 +296,9 @@ section12.output_section[2].alignment = 128;
 
 enet_cpsw1.$name                        = "CONFIG_ENET_CPSW0";
 enet_cpsw1.macAddrConfig                = "Manual Entry";
+enet_cpsw1.macOnlyEn_macPort1           = true;
+enet_cpsw1.macOnlyEn_hostPort           = true;
+enet_cpsw1.macOnlyEn_macPort2           = true;
 enet_cpsw1.txDmaChannel[0].$name        = "ENET_DMA_TX_CH0";
 enet_cpsw1.rxDmaChannel[0].$name        = "ENET_DMA_RX_CH0";
 enet_cpsw1.rxDmaChannel[0].macAddrCount = 2;

--- a/examples/netxduo/enet_netxduo_cpsw_mac/am243x-lp/r5fss0-0_threadx/example.syscfg
+++ b/examples/netxduo/enet_netxduo_cpsw_mac/am243x-lp/r5fss0-0_threadx/example.syscfg
@@ -244,10 +244,15 @@ section9.output_section[1].alignment = 128;
 section9.output_section[2].$name     = ".bss:ENET_ICSSG_OCMC_MEM";
 section9.output_section[2].alignment = 128;
 
-enet_cpsw1.$name                 = "CONFIG_ENET_CPSW0";
-enet_cpsw1.macAddrConfig         = "Manual Entry";
-enet_cpsw1.txDmaChannel[0].$name = "ENET_DMA_TX_CH0";
-enet_cpsw1.rxDmaChannel[0].$name = "ENET_DMA_RX_CH0";
+enet_cpsw1.$name                        = "CONFIG_ENET_CPSW0";
+enet_cpsw1.mdioMode                     = "MDIO_MODE_MANUAL";
+enet_cpsw1.macOnlyEn_hostPort           = true;
+enet_cpsw1.macOnlyEn_macPort1           = true;
+enet_cpsw1.macOnlyEn_macPort2           = true;
+enet_cpsw1.MDIO.MDC.$assign             = "PRG1_MDIO0_MDC";
+enet_cpsw1.txDmaChannel[0].$name        = "ENET_DMA_TX_CH0";
+enet_cpsw1.rxDmaChannel[0].$name        = "ENET_DMA_RX_CH0";
+enet_cpsw1.rxDmaChannel[0].macAddrCount = 2;
 
 const ethphy_cpsw_icssg  = scripting.addModule("/board/ethphy_cpsw_icssg/ethphy_cpsw_icssg", {}, false);
 const ethphy_cpsw_icssg1 = ethphy_cpsw_icssg.addInstance({}, false);
@@ -265,8 +270,8 @@ enet_cpsw1.udmaDrv = udma1;
 netxduo1.$name                          = "CONFIG_NETXDUO0";
 netxduo1.netxduoIfInstance.create(2);
 netxduo1.netxduoIfInstance[0].$name     = "CONFIG_NETX_IF0";
-netxduo1.netxduoIfInstance[0].isDefault = true;
 netxduo1.netxduoIfInstance[1].$name     = "CONFIG_NETX_IF1";
+netxduo1.netxduoIfInstance[1].isDefault = true;
 
 /**
  * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
@@ -278,8 +283,7 @@ i2c1.I2C.SDA.$suggestSolution                   = "I2C0_SDA";
 debug_log.uartLog.UART.RXD.$suggestSolution     = "UART0_RXD";
 debug_log.uartLog.UART.TXD.$suggestSolution     = "UART0_TXD";
 enet_cpsw1.MDIO.$suggestSolution                = "MDIO0";
-enet_cpsw1.MDIO.MDC.$suggestSolution            = "PRG0_PRU1_GPO19";
-enet_cpsw1.MDIO.MDIO.$suggestSolution           = "PRG0_PRU1_GPO18";
+enet_cpsw1.MDIO.MDIO.$suggestSolution           = "PRG1_MDIO0_MDIO";
 enet_cpsw1.RGMII.$suggestSolution               = "CPSW";
 enet_cpsw1.RGMII.RGMII1_RD0.$suggestSolution    = "PRG0_PRU1_GPO7";
 enet_cpsw1.RGMII.RGMII1_RD1.$suggestSolution    = "PRG0_PRU1_GPO9";

--- a/examples/netxduo/enet_netxduo_cpsw_mac/netxduo_cpsw.c
+++ b/examples/netxduo/enet_netxduo_cpsw_mac/netxduo_cpsw.c
@@ -126,7 +126,7 @@ int netxduo_cpsw_main(ULONG arg)
     Board_driversOpen();
 
     DebugP_log("==============================\r\n");
-    DebugP_log("   NETXDUO CPSW SWITCH MODE   \r\n");
+    DebugP_log("   NETXDUO CPSW MAC MODE   \r\n");
     DebugP_log("==============================\r\n");
 
     EnetApp_driverInit();

--- a/examples/netxduo/enet_netxduo_cpsw_switch/am243x-lp/r5fss0-0_threadx/example.syscfg
+++ b/examples/netxduo/enet_netxduo_cpsw_switch/am243x-lp/r5fss0-0_threadx/example.syscfg
@@ -245,13 +245,15 @@ section9.output_section[2].$name     = ".bss:ENET_ICSSG_OCMC_MEM";
 section9.output_section[2].alignment = 128;
 
 enet_cpsw1.$name                          = "CONFIG_ENET_CPSW0";
-enet_cpsw1.macAddrConfig                  = "Manual Entry";
+enet_cpsw1.mdioMode                       = "MDIO_MODE_MANUAL";
 enet_cpsw1.LargePoolPktCount              = 80;
+enet_cpsw1.MDIO.MDC.$assign               = "PRG1_MDIO0_MDC";
 enet_cpsw1.txDmaChannel[0].$name          = "ENET_DMA_TX_CH0";
 enet_cpsw1.rxDmaChannel.create(2);
 enet_cpsw1.rxDmaChannel[0].$name          = "ENET_DMA_RX_CH0";
 enet_cpsw1.rxDmaChannel[1].$name          = "ENET_DMA_RX_CH1";
 enet_cpsw1.rxDmaChannel[1].useDefaultFlow = false;
+enet_cpsw1.rxDmaChannel[1].macAddrCount   = 0;
 
 const ethphy_cpsw_icssg  = scripting.addModule("/board/ethphy_cpsw_icssg/ethphy_cpsw_icssg", {}, false);
 const ethphy_cpsw_icssg1 = ethphy_cpsw_icssg.addInstance({}, false);
@@ -282,8 +284,7 @@ i2c1.I2C.SDA.$suggestSolution                   = "I2C0_SDA";
 debug_log.uartLog.UART.RXD.$suggestSolution     = "UART0_RXD";
 debug_log.uartLog.UART.TXD.$suggestSolution     = "UART0_TXD";
 enet_cpsw1.MDIO.$suggestSolution                = "MDIO0";
-enet_cpsw1.MDIO.MDC.$suggestSolution            = "PRG0_PRU1_GPO19";
-enet_cpsw1.MDIO.MDIO.$suggestSolution           = "PRG0_PRU1_GPO18";
+enet_cpsw1.MDIO.MDIO.$suggestSolution           = "PRG1_MDIO0_MDIO";
 enet_cpsw1.RGMII.$suggestSolution               = "CPSW";
 enet_cpsw1.RGMII.RGMII1_RD0.$suggestSolution    = "PRG0_PRU1_GPO7";
 enet_cpsw1.RGMII.RGMII1_RD1.$suggestSolution    = "PRG0_PRU1_GPO9";

--- a/examples/netxduo/enet_netxduo_cpsw_tcp_client/am243x-lp/r5fss0-0_threadx/example.syscfg
+++ b/examples/netxduo/enet_netxduo_cpsw_tcp_client/am243x-lp/r5fss0-0_threadx/example.syscfg
@@ -114,8 +114,8 @@ general1.$name           = "CONFIG_GENERAL0";
 general1.heap_size       = 34000;
 general1.additional_data = "#include \"ti_enet_config.h\"";
 general1.stack_size      = 8192;
-general1.fiq_stack_size  = 4096;
 general1.irq_stack_size  = 4096;
+general1.fiq_stack_size  = 4096;
 general1.linker.$name    = "TIARMCLANG0";
 
 region1.$name                               = "MEMORY_REGION_CONFIGURATION0";
@@ -245,13 +245,15 @@ section9.output_section[2].$name     = ".bss:ENET_ICSSG_OCMC_MEM";
 section9.output_section[2].alignment = 128;
 
 enet_cpsw1.$name                          = "CONFIG_ENET_CPSW0";
-enet_cpsw1.macAddrConfig                  = "Manual Entry";
+enet_cpsw1.mdioMode                       = "MDIO_MODE_MANUAL";
 enet_cpsw1.LargePoolPktCount              = 80;
+enet_cpsw1.MDIO.MDC.$assign               = "PRG1_MDIO0_MDC";
 enet_cpsw1.txDmaChannel[0].$name          = "ENET_DMA_TX_CH0";
 enet_cpsw1.rxDmaChannel.create(2);
 enet_cpsw1.rxDmaChannel[0].$name          = "ENET_DMA_RX_CH0";
 enet_cpsw1.rxDmaChannel[1].$name          = "ENET_DMA_RX_CH1";
 enet_cpsw1.rxDmaChannel[1].useDefaultFlow = false;
+enet_cpsw1.rxDmaChannel[1].macAddrCount   = 0;
 
 const ethphy_cpsw_icssg  = scripting.addModule("/board/ethphy_cpsw_icssg/ethphy_cpsw_icssg", {}, false);
 const ethphy_cpsw_icssg1 = ethphy_cpsw_icssg.addInstance({}, false);
@@ -282,8 +284,7 @@ i2c1.I2C.SDA.$suggestSolution                   = "I2C0_SDA";
 debug_log.uartLog.UART.RXD.$suggestSolution     = "UART0_RXD";
 debug_log.uartLog.UART.TXD.$suggestSolution     = "UART0_TXD";
 enet_cpsw1.MDIO.$suggestSolution                = "MDIO0";
-enet_cpsw1.MDIO.MDC.$suggestSolution            = "PRG0_PRU1_GPO19";
-enet_cpsw1.MDIO.MDIO.$suggestSolution           = "PRG0_PRU1_GPO18";
+enet_cpsw1.MDIO.MDIO.$suggestSolution           = "PRG1_MDIO0_MDIO";
 enet_cpsw1.RGMII.$suggestSolution               = "CPSW";
 enet_cpsw1.RGMII.RGMII1_RD0.$suggestSolution    = "PRG0_PRU1_GPO7";
 enet_cpsw1.RGMII.RGMII1_RD1.$suggestSolution    = "PRG0_PRU1_GPO9";

--- a/examples/netxduo/enet_netxduo_cpsw_tcp_server/am243x-lp/r5fss0-0_threadx/example.syscfg
+++ b/examples/netxduo/enet_netxduo_cpsw_tcp_server/am243x-lp/r5fss0-0_threadx/example.syscfg
@@ -245,13 +245,15 @@ section9.output_section[2].$name     = ".bss:ENET_ICSSG_OCMC_MEM";
 section9.output_section[2].alignment = 128;
 
 enet_cpsw1.$name                          = "CONFIG_ENET_CPSW0";
-enet_cpsw1.macAddrConfig                  = "Manual Entry";
+enet_cpsw1.mdioMode                       = "MDIO_MODE_MANUAL";
 enet_cpsw1.LargePoolPktCount              = 80;
+enet_cpsw1.MDIO.MDC.$assign               = "PRG1_MDIO0_MDC";
 enet_cpsw1.txDmaChannel[0].$name          = "ENET_DMA_TX_CH0";
 enet_cpsw1.rxDmaChannel.create(2);
 enet_cpsw1.rxDmaChannel[0].$name          = "ENET_DMA_RX_CH0";
 enet_cpsw1.rxDmaChannel[1].$name          = "ENET_DMA_RX_CH1";
 enet_cpsw1.rxDmaChannel[1].useDefaultFlow = false;
+enet_cpsw1.rxDmaChannel[1].macAddrCount   = 0;
 
 const ethphy_cpsw_icssg  = scripting.addModule("/board/ethphy_cpsw_icssg/ethphy_cpsw_icssg", {}, false);
 const ethphy_cpsw_icssg1 = ethphy_cpsw_icssg.addInstance({}, false);
@@ -282,8 +284,7 @@ i2c1.I2C.SDA.$suggestSolution                   = "I2C0_SDA";
 debug_log.uartLog.UART.RXD.$suggestSolution     = "UART0_RXD";
 debug_log.uartLog.UART.TXD.$suggestSolution     = "UART0_TXD";
 enet_cpsw1.MDIO.$suggestSolution                = "MDIO0";
-enet_cpsw1.MDIO.MDC.$suggestSolution            = "PRG0_PRU1_GPO19";
-enet_cpsw1.MDIO.MDIO.$suggestSolution           = "PRG0_PRU1_GPO18";
+enet_cpsw1.MDIO.MDIO.$suggestSolution           = "PRG1_MDIO0_MDIO";
 enet_cpsw1.RGMII.$suggestSolution               = "CPSW";
 enet_cpsw1.RGMII.RGMII1_RD0.$suggestSolution    = "PRG0_PRU1_GPO7";
 enet_cpsw1.RGMII.RGMII1_RD1.$suggestSolution    = "PRG0_PRU1_GPO9";

--- a/examples/netxduo/enet_netxduo_cpsw_udp_client/am243x-lp/r5fss0-0_threadx/example.syscfg
+++ b/examples/netxduo/enet_netxduo_cpsw_udp_client/am243x-lp/r5fss0-0_threadx/example.syscfg
@@ -245,13 +245,15 @@ section9.output_section[2].$name     = ".bss:ENET_ICSSG_OCMC_MEM";
 section9.output_section[2].alignment = 128;
 
 enet_cpsw1.$name                          = "CONFIG_ENET_CPSW0";
-enet_cpsw1.macAddrConfig                  = "Manual Entry";
+enet_cpsw1.mdioMode                       = "MDIO_MODE_MANUAL";
 enet_cpsw1.LargePoolPktCount              = 80;
+enet_cpsw1.MDIO.MDC.$assign               = "PRG1_MDIO0_MDC";
 enet_cpsw1.txDmaChannel[0].$name          = "ENET_DMA_TX_CH0";
 enet_cpsw1.rxDmaChannel.create(2);
 enet_cpsw1.rxDmaChannel[0].$name          = "ENET_DMA_RX_CH0";
 enet_cpsw1.rxDmaChannel[1].$name          = "ENET_DMA_RX_CH1";
 enet_cpsw1.rxDmaChannel[1].useDefaultFlow = false;
+enet_cpsw1.rxDmaChannel[1].macAddrCount   = 0;
 
 const ethphy_cpsw_icssg  = scripting.addModule("/board/ethphy_cpsw_icssg/ethphy_cpsw_icssg", {}, false);
 const ethphy_cpsw_icssg1 = ethphy_cpsw_icssg.addInstance({}, false);
@@ -282,8 +284,7 @@ i2c1.I2C.SDA.$suggestSolution                   = "I2C0_SDA";
 debug_log.uartLog.UART.RXD.$suggestSolution     = "UART0_RXD";
 debug_log.uartLog.UART.TXD.$suggestSolution     = "UART0_TXD";
 enet_cpsw1.MDIO.$suggestSolution                = "MDIO0";
-enet_cpsw1.MDIO.MDC.$suggestSolution            = "PRG0_PRU1_GPO19";
-enet_cpsw1.MDIO.MDIO.$suggestSolution           = "PRG0_PRU1_GPO18";
+enet_cpsw1.MDIO.MDIO.$suggestSolution           = "PRG1_MDIO0_MDIO";
 enet_cpsw1.RGMII.$suggestSolution               = "CPSW";
 enet_cpsw1.RGMII.RGMII1_RD0.$suggestSolution    = "PRG0_PRU1_GPO7";
 enet_cpsw1.RGMII.RGMII1_RD1.$suggestSolution    = "PRG0_PRU1_GPO9";

--- a/examples/netxduo/enet_netxduo_cpsw_udp_client/app_udpclient.c
+++ b/examples/netxduo/enet_netxduo_cpsw_udp_client/app_udpclient.c
@@ -304,7 +304,7 @@ int netxduo_cpsw_main(ULONG arg)
 
             /* Append data to the packet. */
             memset(&gTransmitBuf, 0, sizeof(gTransmitBuf));
-            bufLength = snprintf(gTransmitBuf, sizeof(gTransmitBuf), "Hello over TCP %d", packetIx+1);
+            bufLength = snprintf(gTransmitBuf, sizeof(gTransmitBuf), "Hello over UDP %d", packetIx+1);
             nx_packet_data_append(pPacket, gTransmitBuf, bufLength, &gPacketPool, TX_WAIT_FOREVER);
 
             status =  nx_packet_length_get(pPacket, &packetLength);

--- a/examples/netxduo/enet_netxduo_icssg_mac/am243x-evm/r5fss0-0_threadx/ti-arm-clang/linker.cmd
+++ b/examples/netxduo/enet_netxduo_icssg_mac/am243x-evm/r5fss0-0_threadx/ti-arm-clang/linker.cmd
@@ -25,11 +25,11 @@
  * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
  * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
  */
-__IRQ_STACK_SIZE = 256;
+__IRQ_STACK_SIZE = 4096;
 /* This is the size of stack when R5 is in IRQ mode
  * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
  */
-__FIQ_STACK_SIZE = 256;
+__FIQ_STACK_SIZE = 4096;
 __SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
 __ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
 __UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */

--- a/examples/netxduo/enet_netxduo_icssg_mac/am243x-lp/r5fss0-0_threadx/example.syscfg
+++ b/examples/netxduo/enet_netxduo_icssg_mac/am243x-lp/r5fss0-0_threadx/example.syscfg
@@ -86,27 +86,24 @@ enet_icss1.mdioDisableStateMachineOnInit = true;
 enet_icss1.mdioMode                      = "MDIO_MODE_MANUAL";
 enet_icss1.QoS                           = 3;
 enet_icss1.mode                          = "DUAL MAC";
+enet_icss1.PktInfoOnlyEnable             = true;
 enet_icss1.txDmaChannel[0].$name         = "ENET_DMA_TX_CH0";
 enet_icss1.PRU_ICSSG1_RGMII1.$assign     = "PRU_ICSSG1_RGMII1";
 enet_icss1.rxDmaChannel[0].$name         = "ENET_DMA_RX_CH0";
-enet_icss1.rxDmaChannel[0].useGlobalEvt  = false;
-enet_icss1.rxDmaChannel[0].sizeThreshEn  = 0;
 
 const ethphy_cpsw_icssg  = scripting.addModule("/board/ethphy_cpsw_icssg/ethphy_cpsw_icssg", {}, false);
 const ethphy_cpsw_icssg1 = ethphy_cpsw_icssg.addInstance({}, false);
 ethphy_cpsw_icssg1.$name = "CONFIG_ENET_ETHPHY0";
 enet_icss1.ethphy2       = ethphy_cpsw_icssg1;
 
-enet_icss2.$name                        = "CONFIG_ENET_ICSS1";
-enet_icss2.phyToMacInterfaceMode        = "RGMII";
-enet_icss2.mode                         = "DUAL MAC";
-enet_icss2.dualMacPortSelected          = "ENET_MAC_PORT_2";
-enet_icss2.mdioMdcEnable                = false;
-enet_icss2.QoS                          = 3;
-enet_icss2.txDmaChannel[0].$name        = "ENET_DMA_TX_CH1";
-enet_icss2.rxDmaChannel[0].$name        = "ENET_DMA_RX_CH1";
-enet_icss2.rxDmaChannel[0].useGlobalEvt = false;
-enet_icss2.rxDmaChannel[0].sizeThreshEn = 0;
+enet_icss2.$name                 = "CONFIG_ENET_ICSS1";
+enet_icss2.mode                  = "DUAL MAC";
+enet_icss2.dualMacPortSelected   = "ENET_MAC_PORT_2";
+enet_icss2.mdioMdcEnable         = false;
+enet_icss2.phyToMacInterfaceMode = "RGMII";
+enet_icss2.QoS                   = 3;
+enet_icss2.txDmaChannel[0].$name = "ENET_DMA_TX_CH1";
+enet_icss2.rxDmaChannel[0].$name = "ENET_DMA_RX_CH1";
 
 const ethphy_cpsw_icssg2 = ethphy_cpsw_icssg.addInstance({}, false);
 ethphy_cpsw_icssg2.$name = "CONFIG_ENET_ETHPHY1";
@@ -134,10 +131,10 @@ enet_icss2.udmaDrv = udma1;
 netxduo1.$name                                   = "CONFIG_NETXDUO0";
 netxduo1.netxduoIfInstance.create(2);
 netxduo1.netxduoIfInstance[0].$name              = "CONFIG_NETX_IF0";
-netxduo1.netxduoIfInstance[0].enet_instance_name = "CONFIG_ENET_ICSS0";
 netxduo1.netxduoIfInstance[0].isDefault          = true;
+netxduo1.netxduoIfInstance[0].enet_instance_name = "CONFIG_ENET_ICSS0";
 netxduo1.netxduoIfInstance[1].$name              = "CONFIG_NETX_IF1";
-netxduo1.netxduoIfInstance[1].enet_instance_name = "CONFIG_ENET_ICSS0";
+netxduo1.netxduoIfInstance[1].enet_instance_name = "CONFIG_ENET_ICSS1";
 
 /**
  * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future

--- a/examples/netxduo/enet_netxduo_icssg_mac/am243x-lp/r5fss0-0_threadx/ti-arm-clang/linker.cmd
+++ b/examples/netxduo/enet_netxduo_icssg_mac/am243x-lp/r5fss0-0_threadx/ti-arm-clang/linker.cmd
@@ -25,11 +25,11 @@
  * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
  * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
  */
-__IRQ_STACK_SIZE = 256;
+__IRQ_STACK_SIZE = 4096;
 /* This is the size of stack when R5 is in IRQ mode
  * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
  */
-__FIQ_STACK_SIZE = 256;
+__FIQ_STACK_SIZE = 4096;
 __SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
 __ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
 __UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */

--- a/examples/netxduo/enet_netxduo_icssg_mac/netxduo_icssg.c
+++ b/examples/netxduo/enet_netxduo_icssg_mac/netxduo_icssg.c
@@ -141,7 +141,7 @@ int netxduo_icssg_main(ULONG arg)
     Board_driversOpen();
 
     DebugP_log("==========================\r\n");
-    DebugP_log("      ENET LWIP App       \r\n");
+    DebugP_log("    NETXDUO ICSSG MAC     \r\n");
     DebugP_log("==========================\r\n");
 
     EnetApp_driverInit();

--- a/examples/netxduo/enet_netxduo_icssg_switch/am243x-evm/r5fss0-0_threadx/ti-arm-clang/linker.cmd
+++ b/examples/netxduo/enet_netxduo_icssg_switch/am243x-evm/r5fss0-0_threadx/ti-arm-clang/linker.cmd
@@ -25,11 +25,11 @@
  * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
  * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
  */
-__IRQ_STACK_SIZE = 256;
+__IRQ_STACK_SIZE = 4096;
 /* This is the size of stack when R5 is in IRQ mode
  * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
  */
-__FIQ_STACK_SIZE = 256;
+__FIQ_STACK_SIZE = 4096;
 __SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
 __ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
 __UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */

--- a/examples/netxduo/enet_netxduo_icssg_switch/am243x-lp/r5fss0-0_threadx/example.syscfg
+++ b/examples/netxduo/enet_netxduo_icssg_switch/am243x-lp/r5fss0-0_threadx/example.syscfg
@@ -84,14 +84,12 @@ enet_icss1.phyToMacInterfaceMode         = "RGMII";
 enet_icss1.mdioDisableStateMachineOnInit = true;
 enet_icss1.mdioMode                      = "MDIO_MODE_MANUAL";
 enet_icss1.QoS                           = 3;
-enet_icss1.LargePoolPktCount             = 32;
+enet_icss1.LargePoolPktCount             = 80;
 enet_icss1.txDmaChannel[0].$name         = "ENET_DMA_TX_CH0";
 enet_icss1.rxDmaChannel[0].$name         = "ENET_DMA_RX_CH0";
-enet_icss1.rxDmaChannel[0].PacketsCount  = 8;
 enet_icss1.rxDmaChannel[1].$name         = "ENET_DMA_RX_CH1";
 enet_icss1.rxDmaChannel[1].chIdx         = 1;
 enet_icss1.rxDmaChannel[1].macAddrCount  = 0;
-enet_icss1.rxDmaChannel[1].PacketsCount  = 8;
 enet_icss1.PRU_ICSSG1_RGMII1.$assign     = "PRU_ICSSG1_RGMII1";
 
 const ethphy_cpsw_icssg  = scripting.addModule("/board/ethphy_cpsw_icssg/ethphy_cpsw_icssg", {}, false);
@@ -123,8 +121,9 @@ enet_icss1.udmaDrv = udma1;
 netxduo1.$name                                   = "CONFIG_NETXDUO0";
 netxduo1.netxduoIfInstance.create(1);
 netxduo1.netxduoIfInstance[0].$name              = "CONFIG_NETX_IF0";
-netxduo1.netxduoIfInstance[0].enet_instance_name = "CONFIG_ENET_ICSS0";
 netxduo1.netxduoIfInstance[0].isDefault          = true;
+netxduo1.netxduoIfInstance[0].enet_instance_name = "CONFIG_ENET_ICSS0";
+netxduo1.netxduoIfInstance[0].rxDmaChNum         = ["0","1"];
 
 /**
  * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future

--- a/examples/netxduo/enet_netxduo_icssg_switch/am243x-lp/r5fss0-0_threadx/ti-arm-clang/linker.cmd
+++ b/examples/netxduo/enet_netxduo_icssg_switch/am243x-lp/r5fss0-0_threadx/ti-arm-clang/linker.cmd
@@ -25,11 +25,11 @@
  * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
  * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
  */
-__IRQ_STACK_SIZE = 256;
+__IRQ_STACK_SIZE = 4096;
 /* This is the size of stack when R5 is in IRQ mode
  * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
  */
-__FIQ_STACK_SIZE = 256;
+__FIQ_STACK_SIZE = 4096;
 __SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
 __ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
 __UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */

--- a/examples/netxduo/enet_netxduo_icssg_switch/netxduo_icssg.c
+++ b/examples/netxduo/enet_netxduo_icssg_switch/netxduo_icssg.c
@@ -204,7 +204,7 @@ int netxduo_icssg_main(ULONG arg)
         ifTxChs[k] = txChs[chIds[k]];
     }
     NetxEnetApp_getEnetTypeAndIdFromIfIdx(0u, 0u, &enetType, &instId);
-    macPort = NetxEnetApp_getMacPort(enetType, instId);
+    macPort = NetxEnetApp_getMacPort(0, 0);
 
     status = EnetApp_setMacAddress(enetType, instId, &outArgs.macAddr[0][0]);
     DebugP_assert(status == ENET_SOK);

--- a/sysconfig/networking/.meta/netxduo/netxduo_interface.syscfg.js
+++ b/sysconfig/networking/.meta/netxduo/netxduo_interface.syscfg.js
@@ -231,7 +231,7 @@ function getIfMacPorts()
             let ifCfg = netxduo_module.getIfConfig(netx_instance,Idx);
             let txCh = ifCfg.txDmaChNum
             let enet_instance = null;
-         
+
             let enet_module = null;
             if (getIfEnetType(ifCfg.enet_instance_name) === 'CPSW') {
                 if (netxduo_interface_module.$instances.length == 2) {
@@ -243,7 +243,7 @@ function getIfMacPorts()
             if (getIfEnetType(ifCfg.enet_instance_name) === 'ICSSG') {
                 enet_module = system.modules["/networking/enet_icss/enet_icss"];
                 enet_instance = enet_module.$instances.find(obj => { return obj.$name === ifCfg.enet_instance_name});
-                if (enet_instance.dualMacPortSelected) {
+                if (enet_instance.mode === "DUAL MAC") {
                     ret += enet_instance.dualMacPortSelected; // Dual mac.
                 } else {
                     ret += 'ENET_MAC_PORT_INV'; // Switch


### PR DESCRIPTION
- Fix NETX examples on the AM243x Launchpad board
- Fix various issues with the sysconfig configuration for the NETX examples.