### PR TITLE
AM62Ax Examples Fix

### DIFF
--- a/examples/netxduo/enet_netxduo_cpsw_mac/am62ax-sk/a53ss0-0_threadx/example.syscfg
+++ b/examples/netxduo/enet_netxduo_cpsw_mac/am62ax-sk/a53ss0-0_threadx/example.syscfg
@@ -1,8 +1,9 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM62Ax" --package "AMB" --part "Default" --context "a53ss0-0" --product "MCU_PLUS_SDK@07.03.01"
- * @versions {"tool":"1.20.0+3587"}
+ * @cliArgs --device "AM62Ax" --part "Default" --package "AMB" --context "a53ss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM62A7" --package "FCBGA (AMB)" --variant "AM62A74-M" --context "a53ss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.21.2+3837"}
  */
 
 /**
@@ -54,10 +55,14 @@ mmu_armv83.size      = 0x80000000;
 mmu_armv83.$name     = "DDR_REGION";
 mmu_armv83.attribute = "MAIR7";
 
-enet_cpsw1.$name                 = "CONFIG_ENET_CPSW0";
-enet_cpsw1.macAddrConfig         = "Manual Entry";
-enet_cpsw1.txDmaChannel[0].$name = "ENET_DMA_TX_CH0";
-enet_cpsw1.rxDmaChannel[0].$name = "ENET_DMA_RX_CH0";
+enet_cpsw1.$name                        = "CONFIG_ENET_CPSW0";
+enet_cpsw1.macAddrConfig                = "Manual Entry";
+enet_cpsw1.macOnlyEn_hostPort           = true;
+enet_cpsw1.macOnlyEn_macPort1           = true;
+enet_cpsw1.macOnlyEn_macPort2           = true;
+enet_cpsw1.txDmaChannel[0].$name        = "ENET_DMA_TX_CH0";
+enet_cpsw1.rxDmaChannel[0].$name        = "ENET_DMA_RX_CH0";
+enet_cpsw1.rxDmaChannel[0].macAddrCount = 2;
 
 const ethphy_cpsw_icssg  = scripting.addModule("/board/ethphy_cpsw_icssg/ethphy_cpsw_icssg", {}, false);
 const ethphy_cpsw_icssg1 = ethphy_cpsw_icssg.addInstance({}, false);

--- a/examples/netxduo/enet_netxduo_cpsw_mac/netxduo_cpsw.c
+++ b/examples/netxduo/enet_netxduo_cpsw_mac/netxduo_cpsw.c
@@ -122,11 +122,9 @@ int netxduo_cpsw_main(ULONG arg)
     nx_enet_drv_tx_ch_hndl_t txChs[ENET_SYSCFG_TX_CHANNELS_NUM];
     int32_t status = ENET_SOK;
 
-    Drivers_open();
-    Board_driversOpen();
 
     DebugP_log("==============================\r\n");
-    DebugP_log("   NETXDUO CPSW SWITCH MODE   \r\n");
+    DebugP_log("     NETXDUO CPSW MAC MODE    \r\n");
     DebugP_log("==============================\r\n");
 
     EnetApp_driverInit();

--- a/examples/netxduo/enet_netxduo_cpsw_switch/netxduo_cpsw.c
+++ b/examples/netxduo/enet_netxduo_cpsw_switch/netxduo_cpsw.c
@@ -120,8 +120,6 @@ int netxduo_cpsw_main(ULONG arg)
     nx_enet_drv_tx_ch_hndl_t txChs[ENET_SYSCFG_TX_CHANNELS_NUM];
     int32_t status = ENET_SOK;
 
-    Drivers_open();
-    Board_driversOpen();
 
     DebugP_log("==============================\r\n");
     DebugP_log("   NETXDUO CPSW SWITCH MODE   \r\n");

--- a/examples/netxduo/enet_netxduo_cpsw_tcp_client/app_tcpclient.c
+++ b/examples/netxduo/enet_netxduo_cpsw_tcp_client/app_tcpclient.c
@@ -128,8 +128,6 @@ int netxduo_cpsw_main(ULONG arg)
     bool isLinked;
     int32_t status = ENET_SOK;
 
-    Drivers_open();
-    Board_driversOpen();
 
     DebugP_log("=============================\r\n");
     DebugP_log("   CPSW NETXDUO TCP CLIENT   \r\n");

--- a/examples/netxduo/enet_netxduo_cpsw_tcp_server/app_tcpserver.c
+++ b/examples/netxduo/enet_netxduo_cpsw_tcp_server/app_tcpserver.c
@@ -126,8 +126,6 @@ int netxduo_cpsw_main(ULONG arg)
     bool isLinked;
     int32_t status = ENET_SOK;
 
-    Drivers_open();
-    Board_driversOpen();
 
     DebugP_log("=============================\r\n");
     DebugP_log("   CPSW NETXDUO TCP SERVER   \r\n");

--- a/examples/netxduo/enet_netxduo_cpsw_udp_client/app_udpclient.c
+++ b/examples/netxduo/enet_netxduo_cpsw_udp_client/app_udpclient.c
@@ -128,8 +128,6 @@ int netxduo_cpsw_main(ULONG arg)
     bool isLinked;
     int32_t status = ENET_SOK;
 
-    Drivers_open();
-    Board_driversOpen();
 
     DebugP_log("=============================\r\n");
     DebugP_log("   CPSW NETXDUO UDP CLIENT   \r\n");


### PR DESCRIPTION
Fix issues with NETX examples sysconfig configuration.
Remove duplicate call to Drivers_Open() in NETX examples.