### PR TITLE
More icssg example projects and miscellaneous fixes.

### DIFF
--- a/examples/netxduo/enet_netxduo_cpsw_switch/netxduo_cpsw.c
+++ b/examples/netxduo/enet_netxduo_cpsw_switch/netxduo_cpsw.c
@@ -107,7 +107,6 @@ int netxduo_cpsw_main(ULONG arg)
     Enet_Type enetType;
     uint32_t instId;
     EnetApp_GetMacAddrOutArgs outArgs;
-    Enet_MacPort macPort;
     ULONG ipAddr;
     ULONG netMask;
     ULONG actual_status;
@@ -172,9 +171,9 @@ int netxduo_cpsw_main(ULONG arg)
         NetxEnetDriver_allocTxCh(outArgs.hTxCh, outArgs.maxNumTxPkts, &txChs[k]);
     }
 
-    macPort = NetxEnetApp_getMacPort(0, 0);
+
     EnetApp_getMacAddress(rxChIds[0], &outArgs);
-    NetxEnetDriver_allocIf("PRI", macPort, &outArgs.macAddr[0][0], &rxChs[0], rxChCnt, txChs, txChCnt);
+    NetxEnetDriver_allocIf("PRI", ENET_MAC_PORT_INV, &outArgs.macAddr[0][0], &rxChs[0], rxChCnt, txChs, txChCnt);
 
 
     /* Create an IP instance.  */

--- a/examples/netxduo/enet_netxduo_icssg_gptp/.project/project.js
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/.project/project.js
@@ -1,0 +1,14 @@
+function getComponentProperty(device)
+{
+    return require(`./project_${device}`).getComponentProperty();
+};
+
+function getComponentBuildProperty(buildOption)
+{
+    return require(`./project_${buildOption.device}`).getComponentBuildProperty(buildOption);
+};
+
+module.exports = {
+    getComponentProperty,
+    getComponentBuildProperty,
+}

--- a/examples/netxduo/enet_netxduo_icssg_gptp/.project/project_am243x.js
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/.project/project_am243x.js
@@ -1,0 +1,231 @@
+let path = require('path');
+
+let device = "am243x";
+
+const files = {
+    common: [
+        "gptp_init.c",
+        "default_flow_cfg.c",
+        "tsninit.c",
+        "debug_log.c",
+        "netxduo_gptp_icssg_main.c",
+        "main.c",
+    ],
+};
+
+/* Relative to where the makefile will be generated
+ * Typically at <example_folder>/<BOARD>/<core_os_combo>/<compiler>
+ */
+const filedirs = {
+    common: [
+        "..",       /* core_os_combo base */
+        "../../..", /* Example base */
+    ],
+};
+
+const libdirs = {
+    common: [
+        "generated",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/lib",
+        "${MCU_PLUS_SDK_PATH}/source/kernel/threadx/lib",
+        "${MCU_PLUS_SDK_PATH}/source/fs/filex/lib",
+        "${MCU_PLUS_SDK_PATH}/source/drivers/lib",
+        "${MCU_PLUS_SDK_PATH}/source/board/lib",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/lib",
+        "${MCU_PLUS_SDK_PATH}/source/networking/tsn/lib",
+    ],
+};
+
+const includes = {
+    common: [
+        "${MCU_PLUS_SDK_PATH}/source/board/ethphy/enet/rtos_drivers/include",
+        "${MCU_PLUS_SDK_PATH}/source/board/ethphy/port",
+        "${MCU_PLUS_SDK_PATH}/source/kernel/threadx/threadx_src/common/inc",
+        "${MCU_PLUS_SDK_PATH}/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc",
+        "${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/common/inc",
+        "${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/ports/generic/inc",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/inc",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet/crypto_hw/sa2ul",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/ports/cortex_r5/gnu/inc/",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/inc",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/ports",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/crypto_libraries/inc",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ftp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/http",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mdns",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mqtt",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/nat",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/snmp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/sntp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/telnet",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/tftp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/web",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/websocket",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils/include",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils/V3",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/core",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/phy",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/core",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/soc/k3/am64x_am243x",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include/mdio/V4",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/core/examples/tsn",
+        "${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack",
+        "${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp/tilld",
+        "${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_combase/tilld/sitara",
+        "${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp/gptpconf",
+        "${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_uniconf",
+        "${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_uniconf/yangs",
+    ],
+};
+
+const libs = {
+    common: [
+        "drivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+        "enet-icssg.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+        "board.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+        "libc.a",
+        "libsysbm.a",
+        "tsn_icssg_combase-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+        "tsn_unibase-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+        "tsn_gptp-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+        "tsn_uniconf-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+        "netxduo.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+        "threadx.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+        "filex.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+    ],
+};
+
+const linker_includePath = {
+    common: [
+        "${PROJECT_BUILD_DIR}/syscfg",
+
+    ],
+};
+
+const defines = {
+    common: [
+        "NX_INCLUDE_USER_DEFINE_FILE",
+        "ENET_ENABLE_PER_ICSSG=1",
+        'PRINT_FORMAT_NO_WARNING',
+        'SITARA',
+        'GPTP_ENABLED=1',
+    ],
+};
+
+const cflags = {
+    common: [
+        "--include tsn_buildconf/sitara_buildconf.h",
+    ],
+    release: [
+        "-Oz",
+        "-flto",
+    ],
+    debug: [
+        "-Oz",
+        "-flto",
+    ],
+};
+
+const lflags = {
+    common: [
+        "--zero_init=on",
+        "--use_memset=fast",
+        "--use_memcpy=fast"
+    ],
+};
+
+const loptflags = {
+    release: [
+        "-mcpu=cortex-r5",
+        "-mfloat-abi=hard",
+        "-mfpu=vfpv3-d16",
+        "-mthumb",
+        "-Oz",
+        "-flto"
+    ],
+};
+
+const lnkfiles = {
+    common: [
+        "../linker.cmd",
+    ]
+};
+
+const syscfgfile = "../example.syscfg";
+
+const readmeDoxygenPageTag = "EXAMPLES_ECLIPSE_THREADX_NETXDUO_ICSSG_TSN_GPTP";
+
+const templates =
+[
+    {
+        input: ".project/templates/am243x/threadx/main_threadx.c.xdt",
+        output: "../main.c",
+        options: {
+            entryFunction: "netxduo_icssg_main",
+        },
+    },
+];
+
+const buildOptionCombos = [
+    { device: device, cpu: "r5fss0-0", cgt: "ti-arm-clang", board: "am243x-evm", os: "threadx"},
+    { device: device, cpu: "r5fss0-0", cgt: "ti-arm-clang", board: "am243x-lp", os: "threadx"},
+];
+
+function getComponentProperty() {
+    let property = {};
+
+    property.dirPath = path.resolve(__dirname, "..");
+    property.type = "executable";
+    property.name = "enet_netxduo_icssg_netxduo_gptp";
+    property.isInternal = false;
+    property.buildOptionCombos = buildOptionCombos;
+
+    return property;
+}
+
+function getComponentBuildProperty(buildOption) {
+    let build_property = {};
+
+    build_property.files = files;
+    build_property.filedirs = filedirs;
+    build_property.libdirs = libdirs;
+    build_property.lnkfiles = lnkfiles;
+    build_property.syscfgfile = syscfgfile;
+    build_property.readmeDoxygenPageTag = readmeDoxygenPageTag;
+    build_property.projecspecFileAction = "link";
+    build_property.includes = includes;
+    build_property.templates = templates;
+    build_property.libs = libs;
+    build_property.cflags = cflags;
+    build_property.lflags = lflags;
+    build_property.loptflags = loptflags;
+    build_property.projectspecLnkPath = linker_includePath;
+    build_property.defines = defines;
+
+    return build_property;
+}
+
+module.exports = {
+    getComponentProperty,
+    getComponentBuildProperty,
+};
+

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/example.syscfg
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/example.syscfg
@@ -1,0 +1,203 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM243x_ALV_beta" --part "ALV" --package "ALV" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM2434" --package "FCBGA (ALV)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.21.2+3837"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const eeprom     = scripting.addModule("/board/eeprom/eeprom", {}, false);
+const eeprom1    = eeprom.addInstance();
+const gpio       = scripting.addModule("/drivers/gpio/gpio", {}, false);
+const gpio1      = gpio.addInstance();
+const i2c        = scripting.addModule("/drivers/i2c/i2c", {}, false);
+const i2c1       = i2c.addInstance();
+const i2c2       = i2c.addInstance();
+const pruicss    = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1   = pruicss.addInstance();
+const debug_log  = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg    = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7  = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71 = mpu_armv7.addInstance();
+const mpu_armv72 = mpu_armv7.addInstance();
+const mpu_armv73 = mpu_armv7.addInstance();
+const mpu_armv74 = mpu_armv7.addInstance();
+const mpu_armv75 = mpu_armv7.addInstance();
+const mpu_armv76 = mpu_armv7.addInstance();
+const mpu_armv77 = mpu_armv7.addInstance();
+const enet_icss  = scripting.addModule("/networking/enet_icss/enet_icss", {}, false);
+const enet_icss1 = enet_icss.addInstance();
+const netxduo    = scripting.addModule("/networking/netxduo/netxduo", {}, false);
+const netxduo1   = netxduo.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+eeprom1.$name = "CONFIG_EEPROM0";
+
+gpio1.$name                    = "CONFIG_GPIO0";
+gpio1.pinDir                   = "OUTPUT";
+gpio1.useMcuDomainPeripherals  = true;
+gpio1.MCU_GPIO.$assign         = "MCU_GPIO0";
+gpio1.MCU_GPIO.gpioPin.$assign = "MCU_SPI1_CS0";
+
+i2c1.$name               = "CONFIG_I2C0";
+eeprom1.peripheralDriver = i2c1;
+i2c1.I2C.$assign         = "I2C0";
+i2c1.I2C.SCL.$assign     = "I2C0_SCL";
+i2c1.I2C.SDA.$assign     = "I2C0_SDA";
+i2c1.I2C_child.$name     = "drivers_i2c_v0_i2c_v0_template1";
+
+i2c2.$name           = "CONFIG_I2C1";
+i2c2.I2C.$assign     = "I2C1";
+i2c2.I2C.SCL.$assign = "I2C1_SCL";
+i2c2.I2C.SDA.$assign = "I2C1_SDA";
+i2c2.I2C_child.$name = "drivers_i2c_v0_i2c_v0_template2";
+
+debug_log.enableUartLog = true;
+debug_log.enableCssLog  = false;
+debug_log.uartLog.$name = "CONFIG_UART0";
+
+const uart_v0_template  = scripting.addModule("/drivers/uart/v0/uart_v0_template", {}, false);
+const uart_v0_template1 = uart_v0_template.addInstance({}, false);
+uart_v0_template1.$name = "drivers_uart_v0_uart_v0_template0";
+debug_log.uartLog.child = uart_v0_template1;
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 23;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION4";
+mpu_armv75.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv75.baseAddr          = 0x80000000;
+mpu_armv75.size              = 31;
+
+mpu_armv76.$name             = "CONFIG_MPU_REGION5";
+mpu_armv76.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv76.baseAddr          = 0xA5000000;
+mpu_armv76.size              = 23;
+mpu_armv76.attributes        = "NonCached";
+
+mpu_armv77.$name    = "CONFIG_MPU_REGION6";
+mpu_armv77.size     = 27;
+mpu_armv77.baseAddr = 0x60000000;
+
+enet_icss1.$name                        = "CONFIG_ENET_ICSS0";
+enet_icss1.phyToMacInterfaceMode        = "RGMII";
+enet_icss1.QoS                          = 3;
+enet_icss1.mdioMode                     = "MDIO_MODE_MANUAL";
+enet_icss1.timesyncEnable               = true;
+enet_icss1.timesyncSyncOut_pwidth_WC    = 625000;
+enet_icss1.useAddMacAddr                = true;
+enet_icss1.addMacAddrCnt                = 1;
+enet_icss1.PktInfoOnlyEnable            = true;
+enet_icss1.GigabitSupportEnable         = false;
+enet_icss1.PktInfoOnlyCount             = 128;
+enet_icss1.LargePoolPktCount            = 36;
+enet_icss1.txDmaChannel.create(2);
+enet_icss1.txDmaChannel[0].$name        = "ENET_DMA_TX_CH0";
+enet_icss1.txDmaChannel[1].$name        = "ENET_DMA_TX_CH_PTP";
+enet_icss1.txDmaChannel[1].PacketsCount = 2;
+enet_icss1.rxDmaChannel.create(4);
+enet_icss1.rxDmaChannel[0].$name        = "ENET_DMA_RX_CH0";
+enet_icss1.rxDmaChannel[0].PacketsCount = 16;
+enet_icss1.rxDmaChannel[1].$name        = "ENET_DMA_RX_CH0_PTP";
+enet_icss1.rxDmaChannel[1].macAddrCount = 0;
+enet_icss1.rxDmaChannel[1].PacketsCount = 2;
+enet_icss1.rxDmaChannel[2].$name        = "ENET_DMA_RX_CH1";
+enet_icss1.rxDmaChannel[2].macAddrCount = 0;
+enet_icss1.rxDmaChannel[2].PacketsCount = 16;
+enet_icss1.rxDmaChannel[2].chIdx        = 1;
+enet_icss1.rxDmaChannel[3].$name        = "ENET_DMA_RX_CH1_PTP";
+enet_icss1.rxDmaChannel[3].macAddrCount = 0;
+enet_icss1.rxDmaChannel[3].chIdx        = 1;
+enet_icss1.rxDmaChannel[3].PacketsCount = 2;
+enet_icss1.PRU_ICSSG1_RGMII1.$assign    = "PRU_ICSSG1_RGMII1";
+
+const ethphy_cpsw_icssg  = scripting.addModule("/board/ethphy_cpsw_icssg/ethphy_cpsw_icssg", {}, false);
+const ethphy_cpsw_icssg1 = ethphy_cpsw_icssg.addInstance({}, false);
+ethphy_cpsw_icssg1.$name = "CONFIG_ENET_ETHPHY0";
+enet_icss1.ethphy2       = ethphy_cpsw_icssg1;
+
+const ethphy_cpsw_icssg2 = ethphy_cpsw_icssg.addInstance({}, false);
+ethphy_cpsw_icssg2.$name = "CONFIG_ENET_ETHPHY1";
+enet_icss1.ethphy3       = ethphy_cpsw_icssg2;
+
+enet_icss1.icss                          = pruicss1;
+pruicss1.$name                           = "CONFIG_PRU_ICSS1";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+pruicss1.intcMapping.create(1);
+pruicss1.intcMapping[0].$name            = "CONFIG_ICSS1_INTC_MAPPING0";
+pruicss1.intcMapping[0].event            = "41";
+pruicss1.intcMapping[0].channel          = "7";
+pruicss1.intcMapping[0].host             = "8";
+
+const udma         = scripting.addModule("/drivers/udma/udma", {}, false);
+const udma1        = udma.addInstance({}, false);
+enet_icss1.udmaDrv = udma1;
+
+netxduo1.$name                                   = "CONFIG_NETXDUO0";
+netxduo1.netxduoIfInstance.create(1);
+netxduo1.netxduoIfInstance[0].$name              = "CONFIG_NETX_IF0";
+netxduo1.netxduoIfInstance[0].enet_instance_name = "CONFIG_ENET_ICSS0";
+netxduo1.netxduoIfInstance[0].rxDmaChNum         = ["0","2"];
+netxduo1.netxduoIfInstance[0].isDefault          = true;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.UART.$suggestSolution                  = "USART0";
+debug_log.uartLog.UART.RXD.$suggestSolution              = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$suggestSolution              = "UART0_TXD";
+enet_icss1.PRU_ICSSG1_MDIO.$suggestSolution              = "PRU_ICSSG1_MDIO0";
+enet_icss1.PRU_ICSSG1_MDIO.MDC.$suggestSolution          = "PRG1_MDIO0_MDC";
+enet_icss1.PRU_ICSSG1_MDIO.MDIO.$suggestSolution         = "PRG1_MDIO0_MDIO";
+enet_icss1.PRU_ICSSG1_IEP.$suggestSolution               = "PRU_ICSSG1_IEP0";
+enet_icss1.PRU_ICSSG1_IEP.EDC_LATCH_IN0.$suggestSolution = "PRG1_PRU0_GPO18";
+enet_icss1.PRU_ICSSG1_IEP.EDC_SYNC_OUT0.$suggestSolution = "PRG1_PRU0_GPO19";
+enet_icss1.PRU_ICSSG1_RGMII1.RD0.$suggestSolution        = "PRG1_PRU0_GPO0";
+enet_icss1.PRU_ICSSG1_RGMII1.RD1.$suggestSolution        = "PRG1_PRU0_GPO1";
+enet_icss1.PRU_ICSSG1_RGMII1.RD2.$suggestSolution        = "PRG1_PRU0_GPO2";
+enet_icss1.PRU_ICSSG1_RGMII1.RD3.$suggestSolution        = "PRG1_PRU0_GPO3";
+enet_icss1.PRU_ICSSG1_RGMII1.RXC.$suggestSolution        = "PRG1_PRU0_GPO6";
+enet_icss1.PRU_ICSSG1_RGMII1.RX_CTL.$suggestSolution     = "PRG1_PRU0_GPO4";
+enet_icss1.PRU_ICSSG1_RGMII1.TD0.$suggestSolution        = "PRG1_PRU0_GPO11";
+enet_icss1.PRU_ICSSG1_RGMII1.TD1.$suggestSolution        = "PRG1_PRU0_GPO12";
+enet_icss1.PRU_ICSSG1_RGMII1.TD2.$suggestSolution        = "PRG1_PRU0_GPO13";
+enet_icss1.PRU_ICSSG1_RGMII1.TD3.$suggestSolution        = "PRG1_PRU0_GPO14";
+enet_icss1.PRU_ICSSG1_RGMII1.TXC.$suggestSolution        = "PRG1_PRU0_GPO16";
+enet_icss1.PRU_ICSSG1_RGMII1.TX_CTL.$suggestSolution     = "PRG1_PRU0_GPO15";
+enet_icss1.PRU_ICSSG1_RGMII2.$suggestSolution            = "PRU_ICSSG1_RGMII2";
+enet_icss1.PRU_ICSSG1_RGMII2.RD0.$suggestSolution        = "PRG1_PRU1_GPO0";
+enet_icss1.PRU_ICSSG1_RGMII2.RD1.$suggestSolution        = "PRG1_PRU1_GPO1";
+enet_icss1.PRU_ICSSG1_RGMII2.RD2.$suggestSolution        = "PRG1_PRU1_GPO2";
+enet_icss1.PRU_ICSSG1_RGMII2.RD3.$suggestSolution        = "PRG1_PRU1_GPO3";
+enet_icss1.PRU_ICSSG1_RGMII2.RXC.$suggestSolution        = "PRG1_PRU1_GPO6";
+enet_icss1.PRU_ICSSG1_RGMII2.RX_CTL.$suggestSolution     = "PRG1_PRU1_GPO4";
+enet_icss1.PRU_ICSSG1_RGMII2.TD0.$suggestSolution        = "PRG1_PRU1_GPO11";
+enet_icss1.PRU_ICSSG1_RGMII2.TD1.$suggestSolution        = "PRG1_PRU1_GPO12";
+enet_icss1.PRU_ICSSG1_RGMII2.TD2.$suggestSolution        = "PRG1_PRU1_GPO13";
+enet_icss1.PRU_ICSSG1_RGMII2.TD3.$suggestSolution        = "PRG1_PRU1_GPO14";
+enet_icss1.PRU_ICSSG1_RGMII2.TXC.$suggestSolution        = "PRG1_PRU1_GPO16";
+enet_icss1.PRU_ICSSG1_RGMII2.TX_CTL.$suggestSolution     = "PRG1_PRU1_GPO15";

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/main.c
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2018-2024 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include <tx_api.h>
+
+
+#define MAIN_TASK_PRI  (4)
+
+#define MAIN_TASK_STACK_SIZE (8192U)
+
+uint8_t main_thread_stack[MAIN_TASK_STACK_SIZE] __attribute__((aligned(32)));
+
+TX_THREAD main_thread;
+
+void netxduo_icssg_main(void *args);
+
+void threadx_main(ULONG arg)
+{
+    netxduo_icssg_main(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* Enter the ThreadX kernel.  */
+    tx_kernel_enter();
+}
+
+void tx_application_define(void *first_unused_memory)
+{
+    UINT status;
+
+    status = tx_thread_create(&main_thread,           /* Pointer to the main thread object. */ 
+                              "main_thread",          /* Name of the task for debugging purposes. */
+                              threadx_main,           /* Entry function for the main thread. */
+                              0,                      /* Arguments passed to the entry function. */  
+                              main_thread_stack,      /* Main thread stack. */
+                              MAIN_TASK_STACK_SIZE,   /* Main thread stack size in bytes. */
+                              MAIN_TASK_PRI,          /* Main task priority. */
+                              MAIN_TASK_PRI,          /* Highest priority level of disabled preemption. */
+                              TX_NO_TIME_SLICE,       /* No time slice. */
+                              TX_AUTO_START);         /* Start immediately. */
+
+    DebugP_assertNoLog(status == TX_SUCCESS);
+}
+
+

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/ti-arm-clang/example.projectspec
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/ti-arm-clang/example.projectspec
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM2434_ALV"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Enet Netxduo Icssg Netxduo Gptp"
+        name = "enet_netxduo_icssg_netxduo_gptp_am243x-evm_r5fss0-0_threadx_ti-arm-clang"
+        products="sysconfig;com.ti.MCU_PLUS_SDK_AMXXX"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.1"
+        device="Cortex R.AM2434_ALV"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/board/ethphy/enet/rtos_drivers/include
+            -I${MCU_PLUS_SDK_PATH}/source/board/ethphy/port
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/threadx_src/common/inc
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc
+            -I${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/common/inc
+            -I${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/ports/generic/inc
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/inc
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet/crypto_hw/sa2ul
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/ports/cortex_r5/gnu/inc/
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/inc
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/ports
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/crypto_libraries/inc
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ftp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/http
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mdns
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mqtt
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/nat
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/snmp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/sntp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/telnet
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/tftp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/web
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/websocket
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils/include
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils/V3
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/phy
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/core
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/soc/k3/am64x_am243x
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include/mdio/V4
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/examples/tsn
+            -I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack
+            -I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp/tilld
+            -I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_combase/tilld/sitara
+            -I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp/gptpconf
+            -I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_uniconf
+            -I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_uniconf/yangs
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            --include tsn_buildconf/sitara_buildconf.h
+            -DSOC_AM243X
+            -DNX_INCLUDE_USER_DEFINE_FILE
+            -DENET_ENABLE_PER_ICSSG=1
+            -DPRINT_FORMAT_NO_WARNING
+            -DSITARA
+            -DGPTP_ENABLED=1
+        "
+        linkerBuildOptions="
+            -igenerated
+            -i${MCU_PLUS_SDK_PATH}/source/networking/netxduo/lib
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/threadx/lib
+            -i${MCU_PLUS_SDK_PATH}/source/fs/filex/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/networking/enet/lib
+            -i${MCU_PLUS_SDK_PATH}/source/networking/tsn/lib
+            -i${CG_TOOL_ROOT}/lib
+            -i${PROJECT_BUILD_DIR}/syscfg
+            -m=enet_netxduo_icssg_netxduo_gptp.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+            --gen_xml_func_hash
+            --zero_init=on
+            --use_memset=fast
+            --use_memcpy=fast
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am243x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part ALV --package ALV
+        "
+
+        description="A Enet Netxduo Icssg Netxduo Gptp THREADX project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+                -Oz
+                -flto
+            "
+            linkerBuildOptions="
+                -ldrivers.am243x.r5f.ti-arm-clang.debug.lib
+                -lenet-icssg.am243x.r5f.ti-arm-clang.debug.lib
+                -lboard.am243x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+                -ltsn_icssg_combase-freertos.am243x.r5f.ti-arm-clang.debug.lib
+                -ltsn_unibase-freertos.am243x.r5f.ti-arm-clang.debug.lib
+                -ltsn_gptp-freertos.am243x.r5f.ti-arm-clang.debug.lib
+                -ltsn_uniconf-freertos.am243x.r5f.ti-arm-clang.debug.lib
+                -lnetxduo.am243x.r5f.ti-arm-clang.debug.lib
+                -lthreadx.am243x.r5f.ti-arm-clang.debug.lib
+                -lfilex.am243x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+                -Oz
+                -flto
+            "
+            linkerBuildOptions="
+                -ldrivers.am243x.r5f.ti-arm-clang.release.lib
+                -lenet-icssg.am243x.r5f.ti-arm-clang.release.lib
+                -lboard.am243x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+                -ltsn_icssg_combase-freertos.am243x.r5f.ti-arm-clang.release.lib
+                -ltsn_unibase-freertos.am243x.r5f.ti-arm-clang.release.lib
+                -ltsn_gptp-freertos.am243x.r5f.ti-arm-clang.release.lib
+                -ltsn_uniconf-freertos.am243x.r5f.ti-arm-clang.release.lib
+                -lnetxduo.am243x.r5f.ti-arm-clang.release.lib
+                -lthreadx.am243x.r5f.ti-arm-clang.release.lib
+                -lfilex.am243x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AMXXX_INSTALL_DIR}" scope="project" />
+        <file path="../../../gptp_init.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../../../default_flow_cfg.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../../../tsninit.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../../../debug_log.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../../../netxduo_gptp_icssg_main.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="linker.cmd" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="${MCU_PLUS_SDK_PATH}/docs/api_guide_am243x/EXAMPLES_ECLIPSE_THREADX_NETXDUO_ICSSG_TSN_GPTP.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/ti-arm-clang/linker.cmd
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/ti-arm-clang/linker.cmd
@@ -1,0 +1,216 @@
+#include "ti_enet_config.h"
+
+/* This is the stack that is used by code running within main()
+ * In case of NORTOS,
+ * - This means all the code outside of ISR uses this stack
+ * In case of FreeRTOS
+ * - This means all the code until vTaskStartScheduler() is called in main()
+ *   uses this stack.
+ * - After vTaskStartScheduler() each task created in FreeRTOS has its own stack
+ */
+--stack_size=8192
+/* This is the heap size for malloc() API in NORTOS and FreeRTOS
+ * This is also the heap used by pvPortMalloc in FreeRTOS
+ */
+--heap_size=16000
+-e_vectors  /* This is the entry of the application, _vector MUST be plabed starting address 0x0 */
+
+/* This is the size of stack when R5 is in IRQ mode
+ * In NORTOS,
+ * - Here interrupt nesting is disabled as of now
+ * - This is the stack used by ISRs registered as type IRQ
+ * In FreeRTOS,
+ * - Here interrupt nesting is enabled
+ * - This is stack that is used initally when a IRQ is received
+ * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
+ * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
+ */
+__IRQ_STACK_SIZE = 4096;
+/* This is the size of stack when R5 is in IRQ mode
+ * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
+ */
+__FIQ_STACK_SIZE = 4096;
+__SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
+__ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
+__UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */
+
+SECTIONS
+{
+    /* This has the R5F entry point and vector table, this MUST be at 0x0 */
+    .vectors:{} palign(8) > R5F_VECS
+
+    /* This has the R5F boot code until MPU is enabled,  this MUST be at a address < 0x80000000
+     * i.e this cannot be placed in DDR
+     */
+    GROUP {
+        .text.hwi: palign(8)
+        .text.cache: palign(8)
+        .text.mpu: palign(8)
+        .text.boot: palign(8)
+        .text:abort: palign(8) /* this helps in loading symbols when using XIP mode */
+    } > MSRAM
+
+    UNION:
+    {
+        .icssfw : palign(128)
+
+        .icss_mem: type = NOLOAD {
+#if (ENET_SYSCFG_ICSSG0_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 1)
+        #if(ENET_SYSCFG_DUALMAC_PORT1_ENABLED == 1)
+            *(*gEnetSoc_icssg0HostPoolMem_0)
+            *(*gEnetSoc_icssg0HostQueueMem_0)
+            *(*gEnetSoc_icssg0ScratchMem_0)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                *(*gEnetSoc_icssg0HostPreQueueMem_0)
+            #endif
+        #else
+            *(*gEnetSoc_icssg0HostPoolMem_1)
+            *(*gEnetSoc_icssg0HostQueueMem_1)
+            *(*gEnetSoc_icssg0ScratchMem_1)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                    *(*gEnetSoc_icssg0HostPreQueueMem_1)
+            #endif
+        #endif
+    #endif
+#endif
+#if (ENET_SYSCFG_ICSSG1_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 1)
+        #if(ENET_SYSCFG_DUALMAC_PORT1_ENABLED == 1)
+                *(*gEnetSoc_icssg1HostPoolMem_0)
+                *(*gEnetSoc_icssg1HostQueueMem_0)
+                *(*gEnetSoc_icssg1ScratchMem_0)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                *(*gEnetSoc_icssg1HostPreQueueMem_0)
+            #endif
+        #else
+                *(*gEnetSoc_icssg1HostPoolMem_1)
+                *(*gEnetSoc_icssg1HostQueueMem_1)
+                *(*gEnetSoc_icssg1ScratchMem_1)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                *(*gEnetSoc_icssg1HostPreQueueMem_1)
+            #endif
+        #endif
+    #endif
+#endif
+#if (ENET_SYSCFG_ICSSG0_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 0)
+        *(*gEnetSoc_icssg0PortPoolMem_0)
+        *(*gEnetSoc_icssg0PortPoolMem_1)
+        *(*gEnetSoc_icssg0HostPoolMem_0)
+        *(*gEnetSoc_icssg0HostPoolMem_1)
+        *(*gEnetSoc_icssg0HostQueueMem_0)
+        *(*gEnetSoc_icssg0HostQueueMem_1)
+        *(*gEnetSoc_icssg0ScratchMem_0)
+        *(*gEnetSoc_icssg0ScratchMem_1)
+        #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+            *(*gEnetSoc_icssg0HostPreQueueMem_0)
+            *(*gEnetSoc_icssg0HostPreQueueMem_1)
+        #endif
+    #endif
+#endif
+#if (ENET_SYSCFG_ICSSG1_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 0)
+        *(*gEnetSoc_icssg1PortPoolMem_0)
+        *(*gEnetSoc_icssg1PortPoolMem_1)
+        *(*gEnetSoc_icssg1HostPoolMem_0)
+        *(*gEnetSoc_icssg1HostPoolMem_1)
+        *(*gEnetSoc_icssg1HostQueueMem_0)
+        *(*gEnetSoc_icssg1HostQueueMem_1)
+        *(*gEnetSoc_icssg1ScratchMem_0)
+        *(*gEnetSoc_icssg1ScratchMem_1)
+        #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+            *(*gEnetSoc_icssg1HostPreQueueMem_0)
+            *(*gEnetSoc_icssg1HostPreQueueMem_1)
+        #endif
+    #endif
+#endif
+        }
+
+    } > MSRAM
+
+    /* This is rest of code. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .text:   {} palign(8)   /* This is where code resides */
+        .rodata: {} palign(8)   /* This is where const's go */
+    } > DDR
+
+    /* This is rest of initialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .data:   {} palign(8)   /* This is where initialized globals and static go */
+    } > DDR
+
+    /* This is rest of uninitialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .sysmem: {} palign(8)   /* This is where the malloc heap goes */
+        .stack:  {} palign(8)   /* This is where the main() stack goes */
+    } > DDR
+
+    GROUP {
+        .bss:    {} palign(8)   /* This is where uninitialized globals go */
+        RUN_START(__BSS_START)
+        RUN_END(__BSS_END)
+    } > DDR
+
+    /* This is where the stacks for different R5F modes go */
+    GROUP {
+        .irqstack: {. = . + __IRQ_STACK_SIZE;} align(8)
+        RUN_START(__IRQ_STACK_START)
+        RUN_END(__IRQ_STACK_END)
+        .fiqstack: {. = . + __FIQ_STACK_SIZE;} align(8)
+        RUN_START(__FIQ_STACK_START)
+        RUN_END(__FIQ_STACK_END)
+        .svcstack: {. = . + __SVC_STACK_SIZE;} align(8)
+        RUN_START(__SVC_STACK_START)
+        RUN_END(__SVC_STACK_END)
+        .abortstack: {. = . + __ABORT_STACK_SIZE;} align(8)
+        RUN_START(__ABORT_STACK_START)
+        RUN_END(__ABORT_STACK_END)
+        .undefinedstack: {. = . + __UNDEFINED_STACK_SIZE;} align(8)
+        RUN_START(__UNDEFINED_STACK_START)
+        RUN_END(__UNDEFINED_STACK_END)
+    } > DDR
+
+
+    .enet_dma_mem {
+        *(*ENET_DMA_DESC_MEMPOOL)
+        *(*ENET_DMA_RING_MEMPOOL)
+#if (ENET_SYSCFG_PKT_POOL_ENABLE == 1)
+        *(*ENET_DMA_PKT_MEMPOOL)
+#endif
+    } (NOLOAD) > DDR
+}
+
+/*
+NOTE: Below memory is reserved for DMSC usage
+ - During Boot till security handoff is complete
+   0x701E0000 - 0x701FFFFF (128KB)
+ - After "Security Handoff" is complete (i.e at run time)
+   0x701FC000 - 0x701FFFFF (16KB)
+
+ Security handoff is complete when this message is sent to the DMSC,
+   TISCI_MSG_SEC_HANDOVER
+
+ This should be sent once all cores are loaded and all application
+ specific firewall calls are setup.
+*/
+
+MEMORY
+{
+    R5F_VECS  : ORIGIN = 0x00000000 , LENGTH = 0x00000040
+    R5F_TCMA  : ORIGIN = 0x00000040 , LENGTH = 0x00007FC0
+    R5F_TCMB0 : ORIGIN = 0x41010000 , LENGTH = 0x00008000
+
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with other R5F's
+     */
+    MSRAM     : ORIGIN = 0x70080000 , LENGTH = 0x17C000
+    DDR       : ORIGIN = 0x801F0000 , LENGTH = 0x1F0000
+
+    /* This section can be used to put XIP section of the application in flash, make sure this does not overlap with
+     * other CPUs. Also make sure to add a MPU entry for this section and mark it as cached and code executable
+     */
+    FLASH     : ORIGIN = 0x60100000 , LENGTH = 0x80000
+
+}

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -1,0 +1,460 @@
+
+export MCU_PLUS_SDK_PATH?=$(abspath ../../../../../../../../../..)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).out
+COREOUTNAME:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).optishare.out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	gptp_init.c \
+	default_flow_cfg.c \
+	tsninit.c \
+	debug_log.c \
+	netxduo_gptp_icssg_main.c \
+	main.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+	ti_enet_config.c \
+	ti_enet_open_close.c \
+	ti_enet_soc.c \
+	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/board/ethphy/enet/rtos_drivers/include \
+	-I${MCU_PLUS_SDK_PATH}/source/board/ethphy/port \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/threadx_src/common/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/common/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/ports/generic/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet/crypto_hw/sa2ul \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/ports/cortex_r5/gnu/inc/ \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/ports \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/crypto_libraries/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ftp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/http \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mdns \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mqtt \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/nat \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3 \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/snmp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/sntp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/telnet \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/tftp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/web \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/websocket \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils/include \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils/V3 \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/phy \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/core \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/soc/k3/am64x_am243x \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include/mdio/V4 \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/examples/tsn \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp/tilld \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_combase/tilld/sitara \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp/gptpconf \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_uniconf \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_uniconf/yangs \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM243X \
+	-DNX_INCLUDE_USER_DEFINE_FILE \
+	-DENET_ENABLE_PER_ICSSG=1 \
+	-DPRINT_FORMAT_NO_WARNING \
+	-DSITARA \
+	-DGPTP_ENABLED=1 \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+	--include tsn_buildconf/sitara_buildconf.h \
+
+CFLAGS_release := \
+	-Os \
+	-Oz \
+	-flto \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+	-Oz \
+	-flto \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+LNK_FILES_common = \
+	generated/../linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-igenerated \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/networking/netxduo/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/threadx/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/fs/filex/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/networking/enet/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/networking/tsn/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-ldrivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lenet-icssg.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+	-ltsn_icssg_combase-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ltsn_unibase-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ltsn_gptp-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ltsn_uniconf-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lnetxduo.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lthreadx.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lfilex.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+	-Wl,--gen_xml_func_hash \
+	-Wl,--zero_init=on \
+	-Wl,--use_memset=fast \
+	-Wl,--use_memcpy=fast \
+
+LNKOPTFLAGS_release = \
+		   -mcpu=cortex-r5 \
+		   -mfloat-abi=hard \
+		   -mfpu=vfpv3-d16 \
+		   -mthumb \
+		   -Oz \
+		   -flto \
+
+LIBS_NAME = \
+	drivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	enet-icssg.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+	tsn_icssg_combase-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	tsn_unibase-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	tsn_gptp-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	tsn_uniconf-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	netxduo.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	threadx.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	filex.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	generated \
+	${MCU_PLUS_SDK_PATH}/source/networking/netxduo/lib \
+	${MCU_PLUS_SDK_PATH}/source/kernel/threadx/lib \
+	${MCU_PLUS_SDK_PATH}/source/fs/filex/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/networking/enet/lib \
+	${MCU_PLUS_SDK_PATH}/source/networking/tsn/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am243x:r5fss0-0:threadx:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am243x:r5fss0-0:threadx:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
+SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
+SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am243x:r5fss0-0:threadx:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES) -Wl,--xml_link_info=$(basename $@).lnkxml
+	@echo  Linking: am243x:r5fss0-0:threadx:ti-arm-clang $@ Done !!!
+	@echo  .
+
+coreout: $(COREOUTNAME)
+$(COREOUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Relinking Linking: am243x:r5fss0-0:threadx:ti-arm-clang $@ with OptiShare SSO..
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES) -Wl,--xml_link_info=$(basename $@).lnkxml -Wl,--import_sso=$(SSO_PATH)
+	@echo  Relinking with optishare: am243x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am243x:r5fss0-0:threadx:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am243x:r5fss0-0:threadx:ti-arm-clang enet_netxduo_icssg_netxduo_gptp ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.lnkxml
+	$(RM) \*.ossr
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.lnkxml
+	$(RM) *.ossr
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --context r5fss0-0 --part ALV --package ALV --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --device AM243x_ALV_beta --context r5fss0-0 --part ALV --package ALV --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for enet_netxduo_icssg_netxduo_gptp.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o enet_netxduo_icssg_netxduo_gptp.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).profdata > coverage/enet_netxduo_icssg_netxduo_gptp.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/enet_netxduo_icssg_netxduo_gptp.$(PROFILE).profdata.json --output-json=coverage/enet_netxduo_icssg_netxduo_gptp.$(PROFILE).analysis.json --output=../enet_netxduo_icssg_netxduo_gptp.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,109 @@
+
+# Below variables need to be defined outside this file or via command line
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile_projectspec
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,17 @@
+
+export MCU_PLUS_SDK_PATH?=$(abspath ../../../../../../../../../..)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=enet_netxduo_icssg_netxduo_gptp_am243x-evm_r5fss0-0_threadx_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(MCU_PLUS_SDK_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-evm/r5fss0-0_threadx/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/example.syscfg
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/example.syscfg
@@ -1,0 +1,182 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM243x_ALX_beta" --part "ALX" --package "ALX" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM2434" --package "FCCSP (ALX)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.21.2+3837"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const eeprom     = scripting.addModule("/board/eeprom/eeprom", {}, false);
+const eeprom1    = eeprom.addInstance();
+const i2c        = scripting.addModule("/drivers/i2c/i2c", {}, false);
+const i2c1       = i2c.addInstance();
+const pruicss    = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1   = pruicss.addInstance();
+const debug_log  = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg    = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7  = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71 = mpu_armv7.addInstance();
+const mpu_armv72 = mpu_armv7.addInstance();
+const mpu_armv73 = mpu_armv7.addInstance();
+const mpu_armv74 = mpu_armv7.addInstance();
+const mpu_armv75 = mpu_armv7.addInstance();
+const mpu_armv76 = mpu_armv7.addInstance();
+const enet_icss  = scripting.addModule("/networking/enet_icss/enet_icss", {}, false);
+const enet_icss1 = enet_icss.addInstance();
+const netxduo    = scripting.addModule("/networking/netxduo/netxduo", {}, false);
+const netxduo1   = netxduo.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+eeprom1.$name = "CONFIG_EEPROM0";
+
+i2c1.$name               = "CONFIG_I2C0";
+eeprom1.peripheralDriver = i2c1;
+i2c1.I2C.$assign         = "I2C0";
+i2c1.I2C_child.$name     = "drivers_i2c_v0_i2c_v0_template1";
+
+debug_log.enableUartLog        = true;
+debug_log.enableCssLog         = false;
+debug_log.uartLog.$name        = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign = "USART0";
+
+const uart_v0_template  = scripting.addModule("/drivers/uart/v0/uart_v0_template", {}, false);
+const uart_v0_template1 = uart_v0_template.addInstance({}, false);
+uart_v0_template1.$name = "drivers_uart_v0_uart_v0_template0";
+debug_log.uartLog.child = uart_v0_template1;
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 23;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION5";
+mpu_armv75.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv75.baseAddr          = 0xA5000000;
+mpu_armv75.size              = 23;
+mpu_armv75.attributes        = "NonCached";
+
+mpu_armv76.$name    = "CONFIG_MPU_REGION6";
+mpu_armv76.size     = 27;
+mpu_armv76.baseAddr = 0x60000000;
+
+enet_icss1.$name                        = "CONFIG_ENET_ICSS0";
+enet_icss1.phyToMacInterfaceMode        = "RGMII";
+enet_icss1.mdioMode                     = "MDIO_MODE_MANUAL";
+enet_icss1.QoS                          = 3;
+enet_icss1.timesyncEnable               = true;
+enet_icss1.timesyncSyncOut_pwidth_WC    = 625000;
+enet_icss1.useAddMacAddr                = true;
+enet_icss1.addMacAddrCnt                = 1;
+enet_icss1.PktInfoOnlyEnable            = true;
+enet_icss1.GigabitSupportEnable         = false;
+enet_icss1.PktInfoOnlyCount             = 48;
+enet_icss1.LargePoolPktCount            = 36;
+enet_icss1.txDmaChannel.create(2);
+enet_icss1.txDmaChannel[0].$name        = "ENET_DMA_TX_CH0";
+enet_icss1.txDmaChannel[1].$name        = "ENET_DMA_TX_CH_PTP";
+enet_icss1.txDmaChannel[1].PacketsCount = 4;
+enet_icss1.rxDmaChannel.create(4);
+enet_icss1.rxDmaChannel[0].$name        = "ENET_DMA_RX_CH0";
+enet_icss1.rxDmaChannel[0].PacketsCount = 16;
+enet_icss1.rxDmaChannel[1].$name        = "ENET_DMA_RX_CH0_PTP";
+enet_icss1.rxDmaChannel[1].macAddrCount = 0;
+enet_icss1.rxDmaChannel[1].PacketsCount = 2;
+enet_icss1.rxDmaChannel[2].$name        = "ENET_DMA_RX_CH1";
+enet_icss1.rxDmaChannel[2].macAddrCount = 0;
+enet_icss1.rxDmaChannel[2].chIdx        = 1;
+enet_icss1.rxDmaChannel[2].PacketsCount = 16;
+enet_icss1.rxDmaChannel[3].$name        = "ENET_DMA_RX_CH1_PTP";
+enet_icss1.rxDmaChannel[3].macAddrCount = 0;
+enet_icss1.rxDmaChannel[3].chIdx        = 1;
+enet_icss1.rxDmaChannel[3].PacketsCount = 2;
+enet_icss1.PRU_ICSSG1_RGMII1.$assign    = "PRU_ICSSG1_RGMII1";
+enet_icss1.PRU_ICSSG1_RGMII2.$assign    = "PRU_ICSSG1_RGMII2";
+
+const ethphy_cpsw_icssg  = scripting.addModule("/board/ethphy_cpsw_icssg/ethphy_cpsw_icssg", {}, false);
+const ethphy_cpsw_icssg1 = ethphy_cpsw_icssg.addInstance({}, false);
+ethphy_cpsw_icssg1.$name = "CONFIG_ENET_ETHPHY0";
+enet_icss1.ethphy2       = ethphy_cpsw_icssg1;
+
+const ethphy_cpsw_icssg2 = ethphy_cpsw_icssg.addInstance({}, false);
+ethphy_cpsw_icssg2.$name = "CONFIG_ENET_ETHPHY1";
+enet_icss1.ethphy3       = ethphy_cpsw_icssg2;
+
+enet_icss1.icss                          = pruicss1;
+pruicss1.$name                           = "CONFIG_PRU_ICSS1";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+pruicss1.intcMapping.create(1);
+pruicss1.intcMapping[0].$name            = "CONFIG_ICSS1_INTC_MAPPING0";
+pruicss1.intcMapping[0].event            = "41";
+pruicss1.intcMapping[0].channel          = "7";
+pruicss1.intcMapping[0].host             = "8";
+
+const udma         = scripting.addModule("/drivers/udma/udma", {}, false);
+const udma1        = udma.addInstance({}, false);
+enet_icss1.udmaDrv = udma1;
+
+netxduo1.$name                                   = "CONFIG_NETXDUO0";
+netxduo1.netxduoIfInstance.create(1);
+netxduo1.netxduoIfInstance[0].$name              = "CONFIG_NETX_IF0";
+netxduo1.netxduoIfInstance[0].enet_instance_name = "CONFIG_ENET_ICSS0";
+netxduo1.netxduoIfInstance[0].rxDmaChNum         = ["0","2"];
+netxduo1.netxduoIfInstance[0].isDefault          = true;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+i2c1.I2C.SCL.$suggestSolution                            = "I2C0_SCL";
+i2c1.I2C.SDA.$suggestSolution                            = "I2C0_SDA";
+debug_log.uartLog.UART.RXD.$suggestSolution              = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$suggestSolution              = "UART0_TXD";
+enet_icss1.PRU_ICSSG1_MDIO.$suggestSolution              = "PRU_ICSSG1_MDIO0";
+enet_icss1.PRU_ICSSG1_MDIO.MDC.$suggestSolution          = "PRG1_MDIO0_MDC";
+enet_icss1.PRU_ICSSG1_MDIO.MDIO.$suggestSolution         = "PRG1_MDIO0_MDIO";
+enet_icss1.PRU_ICSSG1_IEP.$suggestSolution               = "PRU_ICSSG1_IEP0";
+enet_icss1.PRU_ICSSG1_IEP.EDC_LATCH_IN0.$suggestSolution = "PRG1_PRU0_GPO18";
+enet_icss1.PRU_ICSSG1_IEP.EDC_SYNC_OUT0.$suggestSolution = "PRG1_PRU0_GPO19";
+enet_icss1.PRU_ICSSG1_RGMII1.RD0.$suggestSolution        = "PRG1_PRU0_GPO0";
+enet_icss1.PRU_ICSSG1_RGMII1.RD1.$suggestSolution        = "PRG1_PRU0_GPO1";
+enet_icss1.PRU_ICSSG1_RGMII1.RD2.$suggestSolution        = "PRG1_PRU0_GPO2";
+enet_icss1.PRU_ICSSG1_RGMII1.RD3.$suggestSolution        = "PRG1_PRU0_GPO3";
+enet_icss1.PRU_ICSSG1_RGMII1.RXC.$suggestSolution        = "PRG1_PRU0_GPO6";
+enet_icss1.PRU_ICSSG1_RGMII1.RX_CTL.$suggestSolution     = "PRG1_PRU0_GPO4";
+enet_icss1.PRU_ICSSG1_RGMII1.TD0.$suggestSolution        = "PRG1_PRU0_GPO11";
+enet_icss1.PRU_ICSSG1_RGMII1.TD1.$suggestSolution        = "PRG1_PRU0_GPO12";
+enet_icss1.PRU_ICSSG1_RGMII1.TD2.$suggestSolution        = "PRG1_PRU0_GPO13";
+enet_icss1.PRU_ICSSG1_RGMII1.TD3.$suggestSolution        = "PRG1_PRU0_GPO14";
+enet_icss1.PRU_ICSSG1_RGMII1.TXC.$suggestSolution        = "PRG1_PRU0_GPO16";
+enet_icss1.PRU_ICSSG1_RGMII1.TX_CTL.$suggestSolution     = "PRG1_PRU0_GPO15";
+enet_icss1.PRU_ICSSG1_RGMII2.RD0.$suggestSolution        = "PRG1_PRU1_GPO0";
+enet_icss1.PRU_ICSSG1_RGMII2.RD1.$suggestSolution        = "PRG1_PRU1_GPO1";
+enet_icss1.PRU_ICSSG1_RGMII2.RD2.$suggestSolution        = "PRG1_PRU1_GPO2";
+enet_icss1.PRU_ICSSG1_RGMII2.RD3.$suggestSolution        = "PRG1_PRU1_GPO3";
+enet_icss1.PRU_ICSSG1_RGMII2.RXC.$suggestSolution        = "PRG1_PRU1_GPO6";
+enet_icss1.PRU_ICSSG1_RGMII2.RX_CTL.$suggestSolution     = "PRG1_PRU1_GPO4";
+enet_icss1.PRU_ICSSG1_RGMII2.TD0.$suggestSolution        = "PRG1_PRU1_GPO11";
+enet_icss1.PRU_ICSSG1_RGMII2.TD1.$suggestSolution        = "PRG1_PRU1_GPO12";
+enet_icss1.PRU_ICSSG1_RGMII2.TD2.$suggestSolution        = "PRG1_PRU1_GPO13";
+enet_icss1.PRU_ICSSG1_RGMII2.TD3.$suggestSolution        = "PRG1_PRU1_GPO14";
+enet_icss1.PRU_ICSSG1_RGMII2.TXC.$suggestSolution        = "PRG1_PRU1_GPO16";
+enet_icss1.PRU_ICSSG1_RGMII2.TX_CTL.$suggestSolution     = "PRG1_PRU1_GPO15";

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/main.c
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2018-2024 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include <tx_api.h>
+
+
+#define MAIN_TASK_PRI  (4)
+
+#define MAIN_TASK_STACK_SIZE (8192U)
+
+uint8_t main_thread_stack[MAIN_TASK_STACK_SIZE] __attribute__((aligned(32)));
+
+TX_THREAD main_thread;
+
+void netxduo_icssg_main(void *args);
+
+void threadx_main(ULONG arg)
+{
+    netxduo_icssg_main(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* Enter the ThreadX kernel.  */
+    tx_kernel_enter();
+}
+
+void tx_application_define(void *first_unused_memory)
+{
+    UINT status;
+
+    status = tx_thread_create(&main_thread,           /* Pointer to the main thread object. */ 
+                              "main_thread",          /* Name of the task for debugging purposes. */
+                              threadx_main,           /* Entry function for the main thread. */
+                              0,                      /* Arguments passed to the entry function. */  
+                              main_thread_stack,      /* Main thread stack. */
+                              MAIN_TASK_STACK_SIZE,   /* Main thread stack size in bytes. */
+                              MAIN_TASK_PRI,          /* Main task priority. */
+                              MAIN_TASK_PRI,          /* Highest priority level of disabled preemption. */
+                              TX_NO_TIME_SLICE,       /* No time slice. */
+                              TX_AUTO_START);         /* Start immediately. */
+
+    DebugP_assertNoLog(status == TX_SUCCESS);
+}
+
+

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/ti-arm-clang/example.projectspec
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/ti-arm-clang/example.projectspec
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM2434_ALX"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Enet Netxduo Icssg Netxduo Gptp"
+        name = "enet_netxduo_icssg_netxduo_gptp_am243x-lp_r5fss0-0_threadx_ti-arm-clang"
+        products="sysconfig;com.ti.MCU_PLUS_SDK_AMXXX"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.1"
+        device="Cortex R.AM2434_ALX"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/board/ethphy/enet/rtos_drivers/include
+            -I${MCU_PLUS_SDK_PATH}/source/board/ethphy/port
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/threadx_src/common/inc
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc
+            -I${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/common/inc
+            -I${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/ports/generic/inc
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/inc
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet/crypto_hw/sa2ul
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/ports/cortex_r5/gnu/inc/
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/inc
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/ports
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/crypto_libraries/inc
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ftp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/http
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mdns
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mqtt
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/nat
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/snmp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/sntp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/telnet
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/tftp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/web
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/websocket
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils/include
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils/V3
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/phy
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/core
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/soc/k3/am64x_am243x
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include/mdio/V4
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/examples/tsn
+            -I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack
+            -I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp/tilld
+            -I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_combase/tilld/sitara
+            -I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp/gptpconf
+            -I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_uniconf
+            -I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_uniconf/yangs
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            --include tsn_buildconf/sitara_buildconf.h
+            -DSOC_AM243X
+            -DNX_INCLUDE_USER_DEFINE_FILE
+            -DENET_ENABLE_PER_ICSSG=1
+            -DPRINT_FORMAT_NO_WARNING
+            -DSITARA
+            -DGPTP_ENABLED=1
+        "
+        linkerBuildOptions="
+            -igenerated
+            -i${MCU_PLUS_SDK_PATH}/source/networking/netxduo/lib
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/threadx/lib
+            -i${MCU_PLUS_SDK_PATH}/source/fs/filex/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/networking/enet/lib
+            -i${MCU_PLUS_SDK_PATH}/source/networking/tsn/lib
+            -i${CG_TOOL_ROOT}/lib
+            -i${PROJECT_BUILD_DIR}/syscfg
+            -m=enet_netxduo_icssg_netxduo_gptp.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+            --gen_xml_func_hash
+            --zero_init=on
+            --use_memset=fast
+            --use_memcpy=fast
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am243x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part ALX --package ALX
+        "
+
+        description="A Enet Netxduo Icssg Netxduo Gptp THREADX project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+                -Oz
+                -flto
+            "
+            linkerBuildOptions="
+                -ldrivers.am243x.r5f.ti-arm-clang.debug.lib
+                -lenet-icssg.am243x.r5f.ti-arm-clang.debug.lib
+                -lboard.am243x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+                -ltsn_icssg_combase-freertos.am243x.r5f.ti-arm-clang.debug.lib
+                -ltsn_unibase-freertos.am243x.r5f.ti-arm-clang.debug.lib
+                -ltsn_gptp-freertos.am243x.r5f.ti-arm-clang.debug.lib
+                -ltsn_uniconf-freertos.am243x.r5f.ti-arm-clang.debug.lib
+                -lnetxduo.am243x.r5f.ti-arm-clang.debug.lib
+                -lthreadx.am243x.r5f.ti-arm-clang.debug.lib
+                -lfilex.am243x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+                -Oz
+                -flto
+            "
+            linkerBuildOptions="
+                -ldrivers.am243x.r5f.ti-arm-clang.release.lib
+                -lenet-icssg.am243x.r5f.ti-arm-clang.release.lib
+                -lboard.am243x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+                -ltsn_icssg_combase-freertos.am243x.r5f.ti-arm-clang.release.lib
+                -ltsn_unibase-freertos.am243x.r5f.ti-arm-clang.release.lib
+                -ltsn_gptp-freertos.am243x.r5f.ti-arm-clang.release.lib
+                -ltsn_uniconf-freertos.am243x.r5f.ti-arm-clang.release.lib
+                -lnetxduo.am243x.r5f.ti-arm-clang.release.lib
+                -lthreadx.am243x.r5f.ti-arm-clang.release.lib
+                -lfilex.am243x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AMXXX_INSTALL_DIR}" scope="project" />
+        <file path="../../../gptp_init.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../../../default_flow_cfg.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../../../tsninit.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../../../debug_log.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../../../netxduo_gptp_icssg_main.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="linker.cmd" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="${MCU_PLUS_SDK_PATH}/docs/api_guide_am243x/EXAMPLES_ECLIPSE_THREADX_NETXDUO_ICSSG_TSN_GPTP.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/ti-arm-clang/linker.cmd
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/ti-arm-clang/linker.cmd
@@ -1,0 +1,217 @@
+#include "ti_enet_config.h"
+
+/* This is the stack that is used by code running within main()
+ * In case of NORTOS,
+ * - This means all the code outside of ISR uses this stack
+ * In case of FreeRTOS
+ * - This means all the code until vTaskStartScheduler() is called in main()
+ *   uses this stack.
+ * - After vTaskStartScheduler() each task created in FreeRTOS has its own stack
+ */
+--stack_size=8192
+/* This is the heap size for malloc() API in NORTOS and FreeRTOS
+ * This is also the heap used by pvPortMalloc in FreeRTOS
+ */
+--heap_size=16000
+-e_vectors  /* This is the entry of the application, _vector MUST be plabed starting address 0x0 */
+
+/* This is the size of stack when R5 is in IRQ mode
+ * In NORTOS,
+ * - Here interrupt nesting is disabled as of now
+ * - This is the stack used by ISRs registered as type IRQ
+ * In FreeRTOS,
+ * - Here interrupt nesting is enabled
+ * - This is stack that is used initally when a IRQ is received
+ * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
+ * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
+ */
+__IRQ_STACK_SIZE = 256;
+/* This is the size of stack when R5 is in IRQ mode
+ * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
+ */
+__FIQ_STACK_SIZE = 256;
+__SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
+__ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
+__UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */
+
+SECTIONS
+{
+    /* This has the R5F entry point and vector table, this MUST be at 0x0 */
+    .vectors:{} palign(8) > R5F_VECS
+
+    /* This has the R5F boot code until MPU is enabled,  this MUST be at a address < 0x80000000
+     * i.e this cannot be placed in DDR
+     */
+    GROUP {
+        .text.hwi: palign(8)
+        .text.cache: palign(8)
+        .text.mpu: palign(8)
+        .text.boot: palign(8)
+        .text:abort: palign(8) /* this helps in loading symbols when using XIP mode */
+    } > MSRAM
+
+    UNION
+    {
+        .icssfw: palign(128)
+
+        .icss_mem: type = NOLOAD, palign(128) {
+#if (ENET_SYSCFG_ICSSG0_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 1)
+        #if(ENET_SYSCFG_DUALMAC_PORT1_ENABLED == 1)
+            *(*gEnetSoc_icssg0HostPoolMem_0)
+            *(*gEnetSoc_icssg0HostQueueMem_0)
+            *(*gEnetSoc_icssg0ScratchMem_0)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                *(*gEnetSoc_icssg0HostPreQueueMem_0)
+            #endif
+        #else
+            *(*gEnetSoc_icssg0HostPoolMem_1)
+            *(*gEnetSoc_icssg0HostQueueMem_1)
+            *(*gEnetSoc_icssg0ScratchMem_1)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                    *(*gEnetSoc_icssg0HostPreQueueMem_1)
+            #endif
+        #endif
+    #endif
+#endif
+#if (ENET_SYSCFG_ICSSG1_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 1)
+        #if(ENET_SYSCFG_DUALMAC_PORT1_ENABLED == 1)
+                *(*gEnetSoc_icssg1HostPoolMem_0)
+                *(*gEnetSoc_icssg1HostQueueMem_0)
+                *(*gEnetSoc_icssg1ScratchMem_0)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                *(*gEnetSoc_icssg1HostPreQueueMem_0)
+            #endif
+        #else
+                *(*gEnetSoc_icssg1HostPoolMem_1)
+                *(*gEnetSoc_icssg1HostQueueMem_1)
+                *(*gEnetSoc_icssg1ScratchMem_1)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                *(*gEnetSoc_icssg1HostPreQueueMem_1)
+            #endif
+        #endif
+    #endif
+#endif
+#if (ENET_SYSCFG_ICSSG0_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 0)
+        *(*gEnetSoc_icssg0PortPoolMem_0)
+        *(*gEnetSoc_icssg0PortPoolMem_1)
+        *(*gEnetSoc_icssg0HostPoolMem_0)
+        *(*gEnetSoc_icssg0HostPoolMem_1)
+        *(*gEnetSoc_icssg0HostQueueMem_0)
+        *(*gEnetSoc_icssg0HostQueueMem_1)
+        *(*gEnetSoc_icssg0ScratchMem_0)
+        *(*gEnetSoc_icssg0ScratchMem_1)
+        #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+            *(*gEnetSoc_icssg0HostPreQueueMem_0)
+            *(*gEnetSoc_icssg0HostPreQueueMem_1)
+        #endif
+    #endif
+#endif
+#if (ENET_SYSCFG_ICSSG1_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 0)
+        *(*gEnetSoc_icssg1PortPoolMem_0)
+        *(*gEnetSoc_icssg1PortPoolMem_1)
+        *(*gEnetSoc_icssg1HostPoolMem_0)
+        *(*gEnetSoc_icssg1HostPoolMem_1)
+        *(*gEnetSoc_icssg1HostQueueMem_0)
+        *(*gEnetSoc_icssg1HostQueueMem_1)
+        *(*gEnetSoc_icssg1ScratchMem_0)
+        *(*gEnetSoc_icssg1ScratchMem_1)
+        #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+            *(*gEnetSoc_icssg1HostPreQueueMem_0)
+            *(*gEnetSoc_icssg1HostPreQueueMem_1)
+        #endif
+    #endif
+#endif
+        }
+    } > MSRAM
+
+    /* This is rest of code. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .text:   {} palign(8)   /* This is where code resides */
+        .rodata: {} palign(8)   /* This is where const's go */
+    } > MSRAM
+
+    /* This is rest of initialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .data:   {} palign(8)   /* This is where initialized globals and static go */
+    } > MSRAM
+
+    /* This is rest of uninitialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .sysmem: {} palign(8)   /* This is where the malloc heap goes */
+        .stack:  {} palign(8)   /* This is where the main() stack goes */
+    } > MSRAM
+
+    GROUP {
+        .bss:    {} palign(8)   /* This is where uninitialized globals go */
+        RUN_START(__BSS_START)
+        RUN_END(__BSS_END)
+    } > MSRAM
+
+    /* This is where the stacks for different R5F modes go */
+    GROUP {
+        .irqstack: {. = . + __IRQ_STACK_SIZE;} align(8)
+        RUN_START(__IRQ_STACK_START)
+        RUN_END(__IRQ_STACK_END)
+        .fiqstack: {. = . + __FIQ_STACK_SIZE;} align(8)
+        RUN_START(__FIQ_STACK_START)
+        RUN_END(__FIQ_STACK_END)
+        .svcstack: {. = . + __SVC_STACK_SIZE;} align(8)
+        RUN_START(__SVC_STACK_START)
+        RUN_END(__SVC_STACK_END)
+        .abortstack: {. = . + __ABORT_STACK_SIZE;} align(8)
+        RUN_START(__ABORT_STACK_START)
+        RUN_END(__ABORT_STACK_END)
+        .undefinedstack: {. = . + __UNDEFINED_STACK_SIZE;} align(8)
+        RUN_START(__UNDEFINED_STACK_START)
+        RUN_END(__UNDEFINED_STACK_END)
+    } > MSRAM
+
+
+    .enet_dma_mem {
+        *(*ENET_DMA_DESC_MEMPOOL)
+        *(*ENET_DMA_RING_MEMPOOL)
+#if (ENET_SYSCFG_PKT_POOL_ENABLE == 1)
+        *(*ENET_DMA_PKT_MEMPOOL)
+#endif
+    } (NOLOAD) > MSRAM
+}
+
+/*
+NOTE: Below memory is reserved for DMSC usage
+ - During Boot till security handoff is complete
+   0x701E0000 - 0x701FFFFF (128KB)
+ - After "Security Handoff" is complete (i.e at run time)
+   0x701FC000 - 0x701FFFFF (16KB)
+
+ Security handoff is complete when this message is sent to the DMSC,
+   TISCI_MSG_SEC_HANDOVER
+
+ This should be sent once all cores are loaded and all application
+ specific firewall calls are setup.
+*/
+
+MEMORY
+{
+    R5F_VECS  : ORIGIN = 0x00000000 , LENGTH = 0x00000040
+    R5F_TCMA  : ORIGIN = 0x00000040 , LENGTH = 0x00007FC0
+    R5F_TCMB0 : ORIGIN = 0x41010000 , LENGTH = 0x00008000
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with other R5F's
+     */
+    MSRAM     : ORIGIN = 0x70080000 , LENGTH = 0x17C000
+
+    /* This section can be used to put XIP section of the application in flash, make sure this does not overlap with
+     * other CPUs. Also make sure to add a MPU entry for this section and mark it as cached and code executable
+     */
+    FLASH     : ORIGIN = 0x60100000 , LENGTH = 0x100000
+
+    /* shared memory segments */
+    /* On R5F,
+     * - make sure there is a MPU entry which maps below regions as non-cache
+     */
+}

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -1,0 +1,460 @@
+
+export MCU_PLUS_SDK_PATH?=$(abspath ../../../../../../../../../..)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).out
+COREOUTNAME:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).optishare.out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	gptp_init.c \
+	default_flow_cfg.c \
+	tsninit.c \
+	debug_log.c \
+	netxduo_gptp_icssg_main.c \
+	main.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+	ti_enet_config.c \
+	ti_enet_open_close.c \
+	ti_enet_soc.c \
+	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/board/ethphy/enet/rtos_drivers/include \
+	-I${MCU_PLUS_SDK_PATH}/source/board/ethphy/port \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/threadx_src/common/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/common/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/ports/generic/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet/crypto_hw/sa2ul \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/ports/cortex_r5/gnu/inc/ \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/ports \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/crypto_libraries/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ftp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/http \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mdns \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mqtt \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/nat \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3 \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/snmp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/sntp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/telnet \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/tftp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/web \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/websocket \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils/include \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/utils/V3 \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/phy \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/core \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/soc/k3/am64x_am243x \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include/mdio/V4 \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/examples/tsn \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp/tilld \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_combase/tilld/sitara \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_gptp/gptpconf \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_uniconf \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/tsn/tsn-stack/tsn_uniconf/yangs \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM243X \
+	-DNX_INCLUDE_USER_DEFINE_FILE \
+	-DENET_ENABLE_PER_ICSSG=1 \
+	-DPRINT_FORMAT_NO_WARNING \
+	-DSITARA \
+	-DGPTP_ENABLED=1 \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+	--include tsn_buildconf/sitara_buildconf.h \
+
+CFLAGS_release := \
+	-Os \
+	-Oz \
+	-flto \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+	-Oz \
+	-flto \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+LNK_FILES_common = \
+	generated/../linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-igenerated \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/networking/netxduo/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/threadx/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/fs/filex/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/networking/enet/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/networking/tsn/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-ldrivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lenet-icssg.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+	-ltsn_icssg_combase-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ltsn_unibase-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ltsn_gptp-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ltsn_uniconf-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lnetxduo.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lthreadx.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lfilex.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+	-Wl,--gen_xml_func_hash \
+	-Wl,--zero_init=on \
+	-Wl,--use_memset=fast \
+	-Wl,--use_memcpy=fast \
+
+LNKOPTFLAGS_release = \
+		   -mcpu=cortex-r5 \
+		   -mfloat-abi=hard \
+		   -mfpu=vfpv3-d16 \
+		   -mthumb \
+		   -Oz \
+		   -flto \
+
+LIBS_NAME = \
+	drivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	enet-icssg.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+	tsn_icssg_combase-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	tsn_unibase-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	tsn_gptp-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	tsn_uniconf-freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	netxduo.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	threadx.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	filex.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	generated \
+	${MCU_PLUS_SDK_PATH}/source/networking/netxduo/lib \
+	${MCU_PLUS_SDK_PATH}/source/kernel/threadx/lib \
+	${MCU_PLUS_SDK_PATH}/source/fs/filex/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/networking/enet/lib \
+	${MCU_PLUS_SDK_PATH}/source/networking/tsn/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am243x:r5fss0-0:threadx:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am243x:r5fss0-0:threadx:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
+SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
+SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am243x:r5fss0-0:threadx:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES) -Wl,--xml_link_info=$(basename $@).lnkxml
+	@echo  Linking: am243x:r5fss0-0:threadx:ti-arm-clang $@ Done !!!
+	@echo  .
+
+coreout: $(COREOUTNAME)
+$(COREOUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Relinking Linking: am243x:r5fss0-0:threadx:ti-arm-clang $@ with OptiShare SSO..
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES) -Wl,--xml_link_info=$(basename $@).lnkxml -Wl,--import_sso=$(SSO_PATH)
+	@echo  Relinking with optishare: am243x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am243x:r5fss0-0:threadx:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am243x:r5fss0-0:threadx:ti-arm-clang enet_netxduo_icssg_netxduo_gptp ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.lnkxml
+	$(RM) \*.ossr
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.lnkxml
+	$(RM) *.ossr
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --context r5fss0-0 --part ALX --package ALX --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --device AM243x_ALX_beta --context r5fss0-0 --part ALX --package ALX --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for enet_netxduo_icssg_netxduo_gptp.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o enet_netxduo_icssg_netxduo_gptp.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=enet_netxduo_icssg_netxduo_gptp.$(PROFILE).profdata > coverage/enet_netxduo_icssg_netxduo_gptp.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/enet_netxduo_icssg_netxduo_gptp.$(PROFILE).profdata.json --output-json=coverage/enet_netxduo_icssg_netxduo_gptp.$(PROFILE).analysis.json --output=../enet_netxduo_icssg_netxduo_gptp.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,109 @@
+
+# Below variables need to be defined outside this file or via command line
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile_projectspec
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,17 @@
+
+export MCU_PLUS_SDK_PATH?=$(abspath ../../../../../../../../../..)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=enet_netxduo_icssg_netxduo_gptp_am243x-lp_r5fss0-0_threadx_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(MCU_PLUS_SDK_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/am243x-lp/r5fss0-0_threadx/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/examples/netxduo/enet_netxduo_icssg_gptp/dataflow.h
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/dataflow.h
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) Texas Instruments Incorporated 2023
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _DATAFLOW_H_
+#define _DATAFLOW_H_
+
+/* ========================================================================== */
+/*                              Include Files                                 */
+/* ========================================================================== */
+/* ========================================================================== */
+/*                              Include Files                                 */
+/* ========================================================================== */
+#include <enet.h>
+#include <kernel/dpl/ClockP.h>
+#include <kernel/dpl/TaskP.h>
+#include <enet_apputils.h>
+#include <enet_appmemutils.h>
+#include "ti_drivers_open_close.h"
+#include "ti_board_open_close.h"
+#include "ti_enet_open_close.h"
+ /* include this header is very important, otherwise some macro is not exported here.
+  * e.g. ENET_SYSCFG_ENABLE_MDIO_MANUALMODE */
+#include "ti_enet_config.h"
+#include <tsn_combase/tilld/cb_lld_ethernet.h>
+#include "tsnapp_porting.h"
+
+/* ========================================================================== */
+/*                           Macros & Typedefs                                */
+/* ========================================================================== */
+
+/* Task stack size */
+#define ENETAPP_TASK_STACK_SZ                     (10U * 1024U)
+
+#define ETH_P_IPV4 (0x0800U)
+
+/* ========================================================================== */
+/*                                Function Declarations                       */
+/* ========================================================================== */
+int EnetApp_lldCfgUpdateCb(cb_socket_lldcfg_update_t *update_cfg);
+void rxDefaultDataCb(void *data, int size, int port, void *cbArg);
+
+#endif //_DATAFLOW_H_

--- a/examples/netxduo/enet_netxduo_icssg_gptp/debug_log.c
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/debug_log.c
@@ -1,0 +1,208 @@
+/*
+ *  Copyright (c) Texas Instruments Incorporated 2023
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ========================================================================== */
+/*                              Include Files                                 */
+/* ========================================================================== */
+
+#include <tsn_combase/combase.h>
+#include <tsn_unibase/unibase_binding.h>
+#include "debug_log.h"
+#include "tsninit.h"
+
+Logger_onConsoleOut sDrvConsoleOut;
+/* Reason: Printing to the console directly will create a lot of timing issue in gptp.
+ * Solution: Writing to a buffer, a log task will print it out a bit later. */
+#if TSN_USE_LOG_BUFFER == 1
+
+static CB_THREAD_MUTEX_T gLogMutex;
+static CB_THREAD_T hLogTask;
+
+#define INIT_LOG_TASK(priority) \
+    if(Logger_startTask(priority) < 0){return -1;}
+
+static uint8_t gLogStackBuf[TSN_TSK_STACK_SIZE]
+__attribute__ ((aligned(TSN_TSK_STACK_ALIGN)));
+static uint8_t gLogBuf[4096];
+static uint8_t gPrintBuf[4096];
+
+
+
+static void *Logger_task(void *arg)
+{
+    int len;
+    DPRINT("%s: started", __func__);
+
+    while(1)
+    {
+        CB_THREAD_MUTEX_LOCK(&gLogMutex);
+        len = strlen((const char*)gLogBuf);
+        if (len > 0)
+        {
+            memcpy(gPrintBuf, gLogBuf, len);
+            gLogBuf[0] = 0;
+            gPrintBuf[len] = 0;
+        }
+        CB_THREAD_MUTEX_UNLOCK(&gLogMutex);
+
+        if (len > 0)
+        {
+            sDrvConsoleOut("%s", (char*)gPrintBuf);
+        }
+
+        CB_USLEEP(10000);
+    }
+    return NULL;
+}
+
+int Logger_logToBuffer(bool flush, const char *str)
+{
+    int usedLen;
+    int remainBufsize;
+    int logLen = strlen(str);
+
+    if (str[0] == 0)
+    {
+        return 0;
+    }
+
+    CB_THREAD_MUTEX_LOCK(&gLogMutex);
+    usedLen = strlen((const char *)gLogBuf);
+    remainBufsize = sizeof(gLogBuf)-usedLen;
+
+#ifdef USE_CRLF
+    char *lf = strrchr(str, '\n');
+    bool replace = BFALSE;
+    if (lf)
+    {
+        *lf = 0;
+        replace = BTRUE;
+    }
+    if (remainBufsize > (logLen+2))
+    {
+        if(replace){
+            snprintf((char *)&gLogBuf[usedLen], remainBufsize, "%s"ENDLINE, str);
+        }else{
+            snprintf((char *)&gLogBuf[usedLen], remainBufsize, "%s", str);
+        }
+    }
+#else
+    if (remainBufsize > logLen)
+    {
+        snprintf((char *)&gLogBuf[usedLen], remainBufsize, "%s", str);
+    }
+#endif
+    else
+    {
+        snprintf((char *)&gLogBuf[0], sizeof(gLogBuf), "log ovflow!"ENDLINE);
+    }
+    CB_THREAD_MUTEX_UNLOCK(&gLogMutex);
+
+    return 0;
+}
+
+static int Logger_startTask(int log_pri)
+{
+    cb_tsn_thread_attr_t attr;
+    int err = 0;
+
+    cb_tsn_thread_attr_init(&attr, log_pri,
+                            sizeof(gLogStackBuf), "log_task");
+    cb_tsn_thread_attr_set_stackaddr(&attr, &gLogStackBuf[0]);
+    if (CB_THREAD_CREATE(&hLogTask, &attr, Logger_task, NULL) < 0)
+    {
+        DPRINT("Failed to create log task!");
+        err = -1;
+    }
+
+    return err;
+}
+
+#else //TSN_USE_LOG_BUFFER != 1
+
+#define INIT_LOG_TASK(priority)
+
+int Logger_directLog(bool flush, const char *str)
+{
+    if (str[0] == 0)
+    {
+        return 0;
+    }
+#ifdef USE_CRLF
+    // SITARA uses \r\n(CR,LF) for the new line so
+    // we have to replace \n in the general log
+    char *lf = strrchr(str, '\n');
+    if (lf)
+    {
+        *lf = 0;
+        flush = BTRUE;
+    }
+#endif
+    sDrvConsoleOut((char*)str);
+    if (flush)
+    {
+        sDrvConsoleOut(ENDLINE);
+    }
+    return 0;
+}
+
+#endif //TSN_USE_LOG_BUFFER != 1
+
+int Logger_init(Logger_onConsoleOut consoleOutCb)
+{
+    if (consoleOutCb)
+    {
+        sDrvConsoleOut = consoleOutCb;
+    }
+#if TSN_USE_LOG_BUFFER == 1
+    if (CB_THREAD_MUTEX_INIT(&gLogMutex, NULL) < 0)
+    {
+        DPRINT("Failed to int mutex!");
+        return -1;
+    }
+#endif
+
+    INIT_LOG_TASK(1);
+    return 0;
+}
+
+void Logger_deInit(void)
+{
+#if TSN_USE_LOG_BUFFER == 1
+    if (hLogTask != NULL)
+    {
+        CB_THREAD_JOIN(hLogTask, NULL);
+        hLogTask = NULL;
+    }
+    CB_THREAD_MUTEX_DESTROY(&gLogMutex);
+#endif
+}

--- a/examples/netxduo/enet_netxduo_icssg_gptp/default_flow_cfg.c
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/default_flow_cfg.c
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) Texas Instruments Incorporated 2023
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ========================================================================== */
+/*                              Include Files                                 */
+/* ========================================================================== */
+#include <tsn_combase/combase.h>
+#include "dataflow.h"
+
+int EnetApp_lldCfgUpdateCb(cb_socket_lldcfg_update_t *update_cfg)
+{
+    int res = 0;
+    if (update_cfg->proto == ETH_P_1588)
+    {
+        update_cfg->numRxChannels = 2;
+        update_cfg->dmaTxChId = ENET_DMA_TX_CH_PTP;
+        update_cfg->dmaRxChId[0] = ENET_DMA_RX_CH0_PTP;
+        update_cfg->dmaRxChId[1] = ENET_DMA_RX_CH1_PTP;
+        update_cfg->nTxPkts = ENET_DMA_TX_CH_PTP_NUM_PKTS;
+        update_cfg->nRxPkts[0] = ENET_DMA_RX_CH0_PTP_NUM_PKTS;
+        update_cfg->nRxPkts[1] = ENET_DMA_RX_CH1_PTP_NUM_PKTS;
+        update_cfg->pktSize = ENET_MEM_LARGE_POOL_PKT_SIZE;
+    }
+
+    return res;
+}

--- a/examples/netxduo/enet_netxduo_icssg_gptp/gptp_init.c
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/gptp_init.c
@@ -1,0 +1,498 @@
+/*
+ *  Copyright (c) Texas Instruments Incorporated 2023
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ========================================================================== */
+/*                              Include Files                                 */
+/* ========================================================================== */
+
+#include <tsn_combase/combase.h>
+#include <tsn_unibase/unibase_binding.h>
+#include <tsn_uniconf/yangs/yang_db_runtime.h>
+#include <tsn_uniconf/yangs/yang_modules.h>
+#include <tsn_gptp/gptpman.h>
+#include <tsn_gptp/tilld/lld_gptp_private.h>
+#include <tsn_gptp/gptpconf/gptpgcfg.h>
+#include <tsn_gptp/gptpconf/xl4-extmod-xl4gptp.h>
+#include <tsn_uniconf/yangs/ieee1588-ptp-tt_access.h>
+#include <tsn_uniconf/ucman.h>
+#include <tsn_uniconf/uc_dbal.h>
+#include "debug_log.h"
+#include "tsninit.h"
+#include "common.h"
+
+/* ========================================================================== */
+/*                           Macros & Typedefs                                */
+/* ========================================================================== */
+#define GPTP_TASK_PRIORITY      (2)
+#define GPTP_TASK_NAME          "gptp2d_task"
+
+/* ========================================================================== */
+/*                         Structure Declarations                             */
+/* ========================================================================== */
+typedef struct
+{
+    char *devlist;
+    const char **confFiles;
+    int domainNum;
+    int domains[GPTP_MAX_DOMAINS];
+    int instNum;
+    int numConf;
+} EnetApp_GptpOpt_t;
+
+/* ========================================================================== */
+/*                          Function Declarations                             */
+/* ========================================================================== */
+
+static void EnetApp_cfgGptpPortDs(yang_db_runtime_dataq_t *ydrd, int instance,
+        int domain, int port_index, bool dbInitFlag);
+static void EnetApp_cfgGptpDefaultDs(yang_db_runtime_dataq_t *ydrd, int instance,
+        int domain, bool dbInitFlag);
+static int EnetApp_gptpYangConfig(yang_db_runtime_dataq_t *ydrd, int instance,
+        int domain, EnetApp_Ctx_t *appCtx);
+static int EnetApp_gptpNonYangConfig(uint8_t instance);
+
+static void *EnetApp_gptpTask(void *arg);
+static int EnetApp_gptpDbInit(EnetApp_ModuleCtx_t* modCtx, EnetApp_dbArgs *dbargs);
+
+/* ========================================================================== */
+/*                            Local Variables                                */
+/* ========================================================================== */
+
+/* gptp can support more than 2 domains but in this example we supports only 2 */
+static EnetApp_GptpOpt_t gGptpOpt =
+{
+    .confFiles = NULL,
+    .domainNum = GPTP_MAX_DOMAINS,
+#if GPTP_MAX_DOMAINS == 1
+    .domains = {0},
+#elif GPTP_MAX_DOMAINS == 2
+    .domains = {0, 1},
+#else
+    #error "Only support 2 domains"
+#endif
+    .instNum = 0,
+    .numConf = 0,
+};
+
+ /*
+  * To shorten the sync interval, configure this parameter on both the master
+  * and slave devices.
+  * Additionally, update the GPTPNET_INTERVAL_TIMEOUT_NSEC macro in the
+  * <platform>_buildconf.h file (e.g., sitara_buildconf.h
+  * #define GPTPNET_INTERVAL_TIMEOUT_NSEC 15625000u) to be less than or equal
+  * the sync interval.
+  *
+  * The SYNC_LOG values adjust the sync interval as follows:
+  * SYNC_LOG = -3: 125 msec
+  * SYNC_LOG = -4: (125/2) msec
+  * SYNC_LOG = -5: (125/4) msec
+  * SYNC_LOG = -6: (125/8) msec
+  * SYNC_LOG = -7: (125/16) msec
+  */
+#ifdef GPTP_QUICKSYNC
+#define SYNC_LOG "-6"
+/* Accepted value is the same as SYNC_LOG */
+#define PDELAY_LOG "-6"
+#else /* !GPTP_QUICKSYNC */
+#define SYNC_LOG "-3"
+#define PDELAY_LOG "0"
+#endif /* GPTP_QUICKSYNC */
+
+static EnetApp_DbNameVal_t gGptpPortDsRw[] =
+{
+    {"port-enable", "true"},
+    {"log-announce-interval", "0"},
+    {"gptp-cap-receipt-timeout", "3"},
+    {"announce-receipt-timeout", "3"},
+    {"initial-log-announce-interval", "0"},
+    {"initial-log-sync-interval", SYNC_LOG},
+    {"sync-receipt-timeout", "3"},
+    {"initial-log-pdelay-req-interval", PDELAY_LOG},
+    {"allowed-lost-responses", "9"},
+    {"allowed-faults", "9"},
+    {"mean-link-delay-thresh", "0x27100000"},
+    {"initial-log-gptp-cap-interval", "3"},
+    {"mgt-log-gptp-cap-interval", "3"},
+};
+
+static EnetApp_DbNameVal_t gGptpPortDsRo[] =
+{
+    {"log-sync-interval", SYNC_LOG},
+    {"minor-version-number", "1"},
+    {"current-log-sync-interval", SYNC_LOG},
+    {"current-log-gptp-cap-interval", "3"},
+    {"current-log-pdelay-req-interval", PDELAY_LOG},
+    {"initial-one-step-tx-oper", "1"},
+    {"current-one-step-tx-oper", "1"},
+    {"use-mgt-one-step-tx-oper", "false"},
+    {"mgt-one-step-tx-oper", "1"},
+    {"use-mgt-log-gptp-cap-interval", "false"},
+};
+
+static EnetApp_DbNameVal_t gGptpDefaultDsRw[] =
+{
+    {"priority1", "248"},
+    {"priority2", "248"},
+    {"external-port-config-enable", "false"},
+    {"clock-quality/clock-class", "cc-default"},
+    {"clock-quality/clock-accuracy", "ca-time-accurate-to-250-ns"},
+    {"clock-quality/offset-scaled-log-variance", "0x436a"}
+};
+
+static EnetApp_DbNameVal_t gGptpDefaultDsRo[] =
+{
+    {"time-source", "internal-oscillator"},
+    {"ptp-timescale", "true"},
+};
+
+/*
+ * To optimize sync speed, consider the following configuration:
+ * {"QUICK_SYNC_ALGO", XL4_EXTMOD_XL4GPTP_QUICK_SYNC_ALGO, 1},
+ * {"PHASE_OFFSET_ADJUST_BY_FREQ", XL4_EXTMOD_XL4GPTP_PHASE_OFFSET_ADJUST_BY_FREQ, 500},
+ *
+ * QUICK_SYNC_ALGO: Enables the slave clock to match the master's rate before applying
+ * phase offset adjustments.
+ * This approach minimizes the interaction between frequency and phase adjustments,
+ * leading to faster synchronization.
+
+ *
+ * PHASE_OFFSET_ADJUST_BY_FREQ: Sets the phase offset adjustment threshold in
+ * nanoseconds.
+ * If the time difference with the master exceeds this threshold,
+ * the slave phase offset is adjusted.
+ * Otherwise, the phase is corrected by modifying the clock frequency.
+ * The phase offset through frequency adjustment is slower than set the phase offset.
+ *
+ * Additionally, consider configuring the SYNC_LOG and PDELAY_LOG intervals.
+ * Shorter intervals result in faster synchronization.
+ *
+ * Disabling BMCA can further improve sync time.
+ * In this case, configure STATIC_PORT_STATE_SLAVE_PORT.
+ *
+ * Adjusting NEIGHBOR_PROP_DELAY can also help reduce sync time.
+ *
+ * Adjusting following parameters can also reduce time to sync stable:
+ * CLOCK_COMPUTE_INTERVAL_MSEC, FREQ_OFFSET_UPDATE_MRATE_PPB,
+ * SKIP_FREQADJ_COUNT_MAX.
+ */
+static EnetApp_DbIntVal_t gGptpNonYangDs[] =
+{
+    {"SINGLE_CLOCK_MODE", XL4_EXTMOD_XL4GPTP_SINGLE_CLOCK_MODE, 1},
+    {"USE_HW_PHASE_ADJUSTMENT", XL4_EXTMOD_XL4GPTP_USE_HW_PHASE_ADJUSTMENT, 1},
+    {"FREQ_OFFSET_IIR_ALPHA_START_VALUE", XL4_EXTMOD_XL4GPTP_FREQ_OFFSET_IIR_ALPHA_START_VALUE, 1},
+    {"FREQ_OFFSET_IIR_ALPHA_STABLE_VALUE", XL4_EXTMOD_XL4GPTP_FREQ_OFFSET_IIR_ALPHA_STABLE_VALUE, 4},
+    {"PHASE_OFFSET_IIR_ALPHA_START_VALUE", XL4_EXTMOD_XL4GPTP_PHASE_OFFSET_IIR_ALPHA_START_VALUE, 1},
+    {"PHASE_OFFSET_IIR_ALPHA_STABLE_VALUE", XL4_EXTMOD_XL4GPTP_PHASE_OFFSET_IIR_ALPHA_STABLE_VALUE, 4},
+    {"MAX_DOMAIN_NUMBER", XL4_EXTMOD_XL4GPTP_MAX_DOMAIN_NUMBER, GPTP_MAX_DOMAINS},
+#ifdef GPTP_QUICKSYNC
+    {"QUICK_SYNC_ALGO", XL4_EXTMOD_XL4GPTP_QUICK_SYNC_ALGO, 1},
+    {"PHASE_OFFSET_ADJUST_BY_FREQ", XL4_EXTMOD_XL4GPTP_PHASE_OFFSET_ADJUST_BY_FREQ, 500},
+    {"FREQ_OFFSET_STABLE_PPB", XL4_EXTMOD_XL4GPTP_FREQ_OFFSET_STABLE_PPB, 500},
+    {"FREQ_OFFSET_UPDATE_MRATE_PPB", XL4_EXTMOD_XL4GPTP_FREQ_OFFSET_UPDATE_MRATE_PPB, 5},
+
+    #ifdef GPTP_MASTER
+        {"STATIC_PORT_STATE_SLAVE_PORT", XL4_EXTMOD_XL4GPTP_STATIC_PORT_STATE_SLAVE_PORT, 0}, // master in disable BMCA
+    #else
+        {"SUPPORT_RUNTIME_NOTICE_CHECK", XL4_EXTMOD_XL4GPTP_SUPPORT_RUNTIME_NOTICE_CHECK, 1}, // only slave can trigger signaling
+        {"STATIC_PORT_STATE_SLAVE_PORT", XL4_EXTMOD_XL4GPTP_STATIC_PORT_STATE_SLAVE_PORT, 1}, // slave in disable BMCA
+    #endif
+    {"CLOCK_COMPUTE_INTERVAL_MSEC", XL4_EXTMOD_XL4GPTP_CLOCK_COMPUTE_INTERVAL_MSEC, 20},
+#else
+    {"CLOCK_COMPUTE_INTERVAL_MSEC", XL4_EXTMOD_XL4GPTP_CLOCK_COMPUTE_INTERVAL_MSEC, 100},
+#endif
+
+#if GPTP_MAX_DOMAINS == 2
+    {"CMLDS_MODE", XL4_EXTMOD_XL4GPTP_CMLDS_MODE, 1},
+    {"SECOND_DOMAIN_THIS_CLOCK", XL4_EXTMOD_XL4GPTP_SECOND_DOMAIN_THIS_CLOCK, 1}
+#endif
+};
+
+static uint8_t gGptpStackBuf[TSN_TSK_STACK_SIZE] \
+__attribute__ ((aligned(TSN_TSK_STACK_ALIGN)));
+
+/* ========================================================================== */
+/*                            Global Variables                                */
+/* ========================================================================== */
+
+extern EnetApp_Ctx_t gAppCtx;
+
+/* ========================================================================== */
+/*                          Function Definitions                              */
+/* ========================================================================== */
+
+int EnetApp_addGptpModCtx(EnetApp_ModuleCtx_t *modCtxTbl)
+{
+    EnetApp_ModuleCtx_t gptpModCtx = {
+        .enable = BTRUE,
+        .stopFlag = BTRUE,
+        .taskPriority = GPTP_TASK_PRIORITY,
+        .taskName = GPTP_TASK_NAME,
+        .stackBuffer = gGptpStackBuf,
+        .stackSize = sizeof(gGptpStackBuf),
+        .onModuleDBInit = EnetApp_gptpDbInit,
+        .onModuleRunner = EnetApp_gptpTask,
+        .appCtx = &gAppCtx
+    };
+    memcpy(&modCtxTbl[ENETAPP_GPTP_TASK_IDX], &gptpModCtx,
+           sizeof(EnetApp_ModuleCtx_t));
+    return 0;
+}
+
+static void EnetApp_cfgGptpPortDs(yang_db_runtime_dataq_t *ydrd, int instance,
+                                  int domain, int port_index, bool dbInitFlag)
+{
+    int i;
+    char buffer[MAX_KEY_SIZE];
+
+    if (!dbInitFlag)
+    {
+        for (i = 0; i < sizeof(gGptpPortDsRw)/sizeof(gGptpPortDsRw[0]); i++)
+        {
+            snprintf(buffer, sizeof(buffer),
+                     "/ieee1588-ptp-tt/ptp/instances/instance|instance-index:%d,%d|"
+                     "/ports/port|port-index:%d|/port-ds/%s",
+                     instance, domain, port_index, gGptpPortDsRw[i].name);
+
+            yang_db_runtime_put_oneline(ydrd, buffer, gGptpPortDsRw[i].val,
+                                        YANG_DB_ONHW_NOACTION);
+        }
+    }
+
+    for (i = 0; i < sizeof(gGptpPortDsRo)/sizeof(gGptpPortDsRo[0]); i++)
+    {
+        snprintf(buffer, sizeof(buffer),
+                 "/ieee1588-ptp-tt/ptp/instances/instance|instance-index:%d,%d|"
+                 "/ports/port|port-index:%d|/port-ds/%s",
+                 instance, domain, port_index, gGptpPortDsRo[i].name);
+
+        yang_db_runtime_put_oneline(ydrd, buffer, gGptpPortDsRo[i].val,
+                                    YANG_DB_ONHW_NOACTION);
+    }
+}
+
+static void EnetApp_cfgGptpDefaultDs(yang_db_runtime_dataq_t *ydrd, int instance,
+                                     int domain, bool dbInitFlag)
+{
+    int i;
+    char buffer[MAX_KEY_SIZE];
+
+    if (!dbInitFlag)
+    {
+        for (i = 0; i < sizeof(gGptpDefaultDsRw)/sizeof(gGptpDefaultDsRw[0]); i++)
+        {
+            snprintf(buffer, sizeof(buffer),
+                     "/ieee1588-ptp-tt/ptp/instances/instance|instance-index:%d,%d|"
+                     "/default-ds/%s",
+                     instance, domain, gGptpDefaultDsRw[i].name);
+            yang_db_runtime_put_oneline(ydrd, buffer, gGptpDefaultDsRw[i].val,
+                                        YANG_DB_ONHW_NOACTION);
+        }
+    }
+
+    for (i = 0; i < sizeof(gGptpDefaultDsRo)/sizeof(gGptpDefaultDsRo[0]); i++)
+    {
+        snprintf(buffer, sizeof(buffer),
+                 "/ieee1588-ptp-tt/ptp/instances/instance|instance-index:%d,%d|"
+                 "/default-ds/%s",
+                 instance, domain, gGptpDefaultDsRo[i].name);
+        yang_db_runtime_put_oneline(ydrd, buffer, gGptpDefaultDsRo[i].val,
+                                    YANG_DB_ONHW_NOACTION);
+    }
+}
+
+static int EnetApp_gptpYangConfig(yang_db_runtime_dataq_t *ydrd, int instance,
+               int domain, EnetApp_Ctx_t *appCtx)
+{
+    char buffer[MAX_KEY_SIZE];
+    char value_str[32];
+    const char *plus;
+    int i, res = 0;
+
+    DPRINT("%s:domain=%d", __func__, domain);
+
+    do {
+        /* skip setting of 'rw' yang configs when db is already initialized */
+        if (!appCtx->dbInitFlag)
+        {
+            plus = ((instance | domain) != 0) ? "+": "";
+            snprintf(buffer, sizeof(buffer), "/ieee1588-ptp-tt/ptp/instance-domain-map%s",
+                     plus);
+            snprintf(value_str, sizeof(value_str), "0x%04x", instance<<8|domain);
+            yang_db_runtime_put_oneline(ydrd, buffer,
+                                        value_str, YANG_DB_ONHW_NOACTION);
+        }
+
+        /* set for default-ds */
+        EnetApp_cfgGptpDefaultDs(ydrd, instance, domain, appCtx->dbInitFlag);
+
+        // portindex starts from 1
+        for (i = 0; i < appCtx->netdevSize; i++)
+        {
+            /* skip setting of 'rw' yang configs when db is already initialized */
+            if (!appCtx->dbInitFlag)
+            {
+                snprintf(buffer, sizeof(buffer),
+                         "/ieee1588-ptp-tt/ptp/instances/instance|instance-index:%d,%d|"
+                         "/ports/port|port-index:%d|/underlying-interface",
+                         instance, domain, i+1);
+                yang_db_runtime_put_oneline(ydrd, buffer, appCtx->netdev[i],
+                                            YANG_DB_ONHW_NOACTION);
+            }
+
+            /* set for port-ds */
+            EnetApp_cfgGptpPortDs(ydrd, instance, domain, i+1, appCtx->dbInitFlag);
+        }
+
+        /* skip setting of 'rw' yang configs when db is already initialized */
+        if (!appCtx->dbInitFlag)
+        {
+            /* disable performance by default */
+            snprintf(buffer, sizeof(buffer),
+                     "/ieee1588-ptp-tt/ptp/instances/instance|instance-index:%d,%d|"
+                     "/performance-monitoring-ds/enable",
+                     instance, domain);
+            yang_db_runtime_put_oneline(ydrd, buffer, "false", YANG_DB_ONHW_NOACTION);
+        }
+    } while (0);
+
+    return res;
+}
+
+static int EnetApp_gptpNonYangConfig(uint8_t instance)
+{
+    int i;
+    int res;
+
+    for (i = 0; i < sizeof(gGptpNonYangDs)/sizeof(gGptpNonYangDs[0]); i++)
+    {
+        res = gptpgcfg_set_item(instance, gGptpNonYangDs[i].item,  YDBI_CONFIG,
+                    &gGptpNonYangDs[i].val, sizeof(gGptpNonYangDs[i].val));
+        if (res == 0)
+        {
+            DPRINT("%s:XL4_EXTMOD_XL4GPTP_%s=%d", __func__,
+                   gGptpNonYangDs[i].name, gGptpNonYangDs[i].val);
+        }
+        else
+        {
+            DPRINT("%s: failed to set nonyange param: %s",
+                   __func__, gGptpNonYangDs[i].name);
+            break;
+        }
+    }
+    return res;
+}
+
+static void *EnetApp_gptpTask(void *arg)
+{
+    int i;
+    int res = 0;
+    EnetApp_ModuleCtx_t *modCtx = (EnetApp_ModuleCtx_t *)arg;
+    EnetApp_Ctx_t *appCtx = modCtx->appCtx;
+    const char *netdevs[CB_MAX_NETDEVNAME];
+
+    for (i = 0; i < appCtx->netdevSize; i++)
+    {
+        netdevs[i] = appCtx->netdev[i];
+    }
+
+    res = gptpgcfg_init(appCtx->dbName, gGptpOpt.confFiles,
+                        gGptpOpt.instNum, true, EnetApp_gptpNonYangConfig);
+    if (res != 0)
+    {
+        DPRINT("%s: gptpgcfg_init() error", __func__);
+    }
+    else
+    {
+        /* This function has a true loop inside */
+        res = gptpman_run(gGptpOpt.instNum, netdevs, appCtx->netdevSize,
+                        NULL, &modCtx->stopFlag);
+        if (res != 0)
+        {
+            DPRINT("%s: gptpman_run() error", __func__);
+        }
+    }
+    gptpgcfg_close(gGptpOpt.instNum);
+    return NULL;
+}
+
+static int EnetApp_gptpDbInit(EnetApp_ModuleCtx_t* modCtx, EnetApp_dbArgs *dbargs)
+{
+    EnetApp_Ctx_t *appCtx = modCtx->appCtx;
+    int res = 0;
+    int i;
+
+    if (gGptpOpt.numConf == 0)
+    {
+        /* There is no config file is specified, set config file for gptp*/
+        for (i = 0; i < gGptpOpt.domainNum; i++)
+        {
+            res = EnetApp_gptpYangConfig(dbargs->ydrd, gGptpOpt.instNum,
+                        gGptpOpt.domains[i], appCtx);
+            if (res)
+            {
+                DPRINT("Failed to set gptp run time config");
+            }
+        }
+    }
+
+    return res;
+}
+#ifdef GPTP_QUICKSYNC
+#ifdef GPTP_SLAVE
+#include <tsn_gptp/gptpclock.h>
+int EnetApp_adjustTimeInterval()
+{
+    int di;
+    int res= -1;
+    for (di = 0; di < gGptpOpt.domainNum; di++)
+    {
+        gmsync_status_t gmsts = gptpclock_get_gmsync(gGptpOpt.instNum,
+                    gGptpOpt.domains[di]);
+        if (GMSYNC_SYNC_STABLE != gmsts) {continue;}
+        if (GMSYNC_SYNC_STABLE == gmsts)
+        {
+            UB_TLOG(UBL_INFO, "di=%d, GM is stable. Adjust messages interval now\n", di);
+
+            int8_t logSync=-3; // default: 125ms
+            int8_t logAnnounce=-128; // do not change Announce
+            int8_t logPdelayReq=0; // default: 1s
+
+            gptpgcfg_trigger_msg_interval_request(gGptpOpt.instNum, logSync, logAnnounce, logPdelayReq);
+            res=0;
+            break;
+        }
+    }
+
+    return res;
+}
+#endif // GPTP_SLAVE
+#endif // GPTP_QUICKSYNC

--- a/examples/netxduo/enet_netxduo_icssg_gptp/netxduo_gptp_icssg_main.c
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/netxduo_gptp_icssg_main.c
@@ -47,10 +47,16 @@
 #include "ti_drivers_open_close.h"
 #include "ti_board_open_close.h"
 #include "ti_board_config.h"
-#include "ti_enet_open_close.h"
 #include "ti_enet_config.h"
 #include <kernel/dpl/TaskP.h>
 #include <kernel/dpl/ClockP.h>
+
+#include <tsn_combase/combase.h>
+#include <tsn_combase/combase_link.h>
+#include "debug_log.h"
+#include "dataflow.h"
+#include "tsninit.h"
+#include "enetapp_icssg.h"
 
 #include <include/per/icssg.h>
 #include <priv/per/icssg_priv.h>
@@ -68,16 +74,20 @@
 /*                           Macros & Typedefs                                */
 /* ========================================================================== */
 
+#define LOG_BUFFER_SIZE (1024)
+
 #define PACKET_SIZE     1536
 #define POOL_SIZE      ((sizeof(NX_PACKET) + PACKET_SIZE) * (ENET_SYSCFG_TOTAL_NUM_RX_PKT + ENET_SYSCFG_TOTAL_NUM_TX_PKT))
 
-#define IP_THREAD_STACK_SIZE        8192u
-#define IP_ARP_THREAD_STACK_SIZE    8192u
+#define IP_THREAD_STACK_SIZE        4096u
+#define IP_ARP_THREAD_STACK_SIZE    4096u
+
 
 
 /* ========================================================================== */
 /*                            Global Variables                                */
 /* ========================================================================== */
+
 
 static uint8_t gIpThreadStack[IP_THREAD_STACK_SIZE]__attribute__((aligned(ENET_UTILS_CACHELINE_SIZE)));
 static uint8_t gIpArpThreadStack[IP_ARP_THREAD_STACK_SIZE]__attribute__((aligned(ENET_UTILS_CACHELINE_SIZE)));
@@ -89,11 +99,22 @@ static NX_IP gIp;
 static NX_DHCP gDhcpClient;
 
 
+/* these vars are shared with gptp task to configure gptp, put it in the global mem */
+static char g_netdevices[MAX_NUM_MAC_PORTS][CB_MAX_NETDEVNAME] = {0};
+
+
+#define EnetAppAbort(message) \
+    EnetAppUtils_print(message);                \
+    EnetAppUtils_assert(false);
+
+
 /* ========================================================================== */
 /*                          Function Prototypes                               */
 /* ========================================================================== */
 
 static int32_t EnetApp_setMacAddress(const Enet_Type enetType, uint32_t instId, Enet_MacPort macPort, uint8_t macAddr[ENET_MAC_ADDR_LEN]);
+
+static int EnetApp_initTsn(Enet_Type enetType, uint32_t instId, Enet_MacPort macPortList[], uint8_t numMacPort);
 
 
 /* ========================================================================== */
@@ -105,17 +126,20 @@ int netxduo_icssg_main(ULONG arg)
     Enet_Type enetType;
     uint32_t instId;
     Enet_MacPort macPort;
+    uint32_t rxChCnt;
+    uint32_t txChCnt;
     ULONG actual_status;
     ULONG netMask;
     ULONG ipAddr;
+    Enet_MacPort macPortList[ENET_SYSCFG_MAX_MAC_PORTS];
+    uint8_t numMacPort;
     EnetApp_GetMacAddrOutArgs outArgs;
-    uint32_t rxChCnt;
-    uint32_t txChCnt;
+    nx_enet_drv_rx_ch_hndl_t rxChs[ENET_NETX_MAX_RX_CHANNELS_PER_PHERIPHERAL];
+    nx_enet_drv_tx_ch_hndl_t txChs[ENET_NETX_MAX_RX_CHANNELS_PER_PHERIPHERAL];
     const uint32_t *rxChIds;
     const uint32_t *txChIds;
-    nx_enet_drv_rx_ch_hndl_t rxChs[ENET_SYSCFG_RX_FLOWS_NUM];
-    nx_enet_drv_tx_ch_hndl_t txChs[ENET_SYSCFG_TX_CHANNELS_NUM];
     int32_t status = ENET_SOK;
+    int res;
 
     Drivers_open();
     Board_driversOpen();
@@ -126,21 +150,24 @@ int netxduo_icssg_main(ULONG arg)
 
 
     EnetApp_getEnetInstInfo(CONFIG_ENET_ICSS0, &enetType, &instId);
-
     EnetAppUtils_enableClocks(enetType, instId);
 
     EnetApp_driverInit();
     status = EnetApp_driverOpen(enetType, instId);
     DebugP_assert(status == ENET_SOK);
 
+    EnetApp_getEnetInstMacInfo(enetType, instId, &macPortList[0], &numMacPort);
+    res = EnetApp_initTsn(enetType, instId, &macPortList[0], numMacPort);
+    EnetAppUtils_assert(res == ENET_SOK);
 
+
+#if 1
     /* Initialize the NetX system.  */
     nx_system_initialize();
 
     /* Create a packet pool.  */
     status = nx_packet_pool_create(&gPacketPool, "NetX Main Packet Pool", PACKET_SIZE, &gPoolMem[0], POOL_SIZE);
     EnetAppUtils_assert(status == NX_SUCCESS);
-
 
     /* Allocate NetX Rx channel and corresponding buffers. */
     NetxEnetApp_getAllRxChIDs(&rxChIds, &rxChCnt);
@@ -176,6 +203,7 @@ int netxduo_icssg_main(ULONG arg)
     NetxEnetDriver_allocIf("PRI", ENET_MAC_PORT_INV, &outArgs.macAddr[0][0], &rxChs[0], rxChCnt, &txChs[0], txChCnt);
 
 
+
     /* Create an IP instance.  */
     status = nx_ip_create(&gIp, "NetX IP Instance 0", IP_ADDRESS(0, 0, 0, 0), 0xFFFFFF00UL, &gPacketPool, _nx_enet_driver, (void *)&gIpThreadStack[0], IP_THREAD_STACK_SIZE, 1);
     EnetAppUtils_assert(status == NX_SUCCESS);
@@ -200,6 +228,7 @@ int netxduo_icssg_main(ULONG arg)
 
     nx_dhcp_interface_enable(&gDhcpClient, 0u);
 
+
     /* Start the DHCP Client.  */
     status = nx_dhcp_interface_start(&gDhcpClient, 0u);
     EnetAppUtils_assert(status == NX_SUCCESS);
@@ -223,10 +252,14 @@ int netxduo_icssg_main(ULONG arg)
 
     DebugP_log("Local Interface IP is: %lu.%lu.%lu.%lu\n", ((ipAddr >> 24u) & 0xFF), ((ipAddr >> 16u) & 0xFF), ((ipAddr >> 8u) & 0xFF), (ipAddr & 0xFF));
 
+    /* Notify the TSN stack that the link is up. */
+    notify_linkchange();
+
     while (1) {
 
         tx_thread_sleep(100);
     }
+#endif
 
     return 0;
 }
@@ -287,3 +320,80 @@ static int32_t EnetApp_setMacAddress(const Enet_Type enetType, uint32_t instId, 
     return status;
 }
 
+
+void EnetApp_updateIcssgInitCfg(Enet_Type enetType, uint32_t instId, Icssg_Cfg *icssgCfg)
+{
+#if (ENET_SYSCFG_ENABLE_MDIO_MANUALMODE == 1U)
+    icssgCfg->mdioLinkIntCfg.mdioLinkStateChangeCb = NULL;
+    icssgCfg->mdioLinkIntCfg.mdioLinkStateChangeCbArg  = NULL;
+#else
+    #if (ENET_SYSCFG_ENABLE_EXTPHY == 1U)
+        EnetApp_initMdioLinkIntCfg(enetType, instId, icssgCfg);
+    #else
+        icssgCfg->mdioLinkIntCfg.mdioLinkStateChangeCb = &EnetApp_mdioLinkStatusChange;
+        icssgCfg->mdioLinkIntCfg.mdioLinkStateChangeCbArg  = NULL;
+    #endif
+    EnetApp_updateMdioLinkIntCfg(enetType, instId, &icssgCfg->mdioLinkIntCfg);
+#endif
+}
+
+void ConsolePrint(const char *pcString, ...)
+{
+    /* Use DebugP_log() because EnetAppUtils_print() has limit bufsize */
+    va_list args;
+    char buffer[LOG_BUFFER_SIZE];
+
+    va_start(args, pcString);
+    vsnprintf(buffer, sizeof(buffer), pcString, args);
+    va_end(args);
+
+    DebugP_log("%s", buffer);
+}
+
+
+
+static int EnetApp_initTsn(Enet_Type enetType, uint32_t instId, Enet_MacPort macPortList[], uint8_t numMacPort)
+{
+    lld_ethdev_t ethdevs[MAX_NUMBER_ENET_DEVS] = {0};
+    EnetApp_GetMacAddrOutArgs outArgs;
+    int i;
+    int res = 0;
+    AppTsnCfg_t appCfg =
+    {
+        .consoleOutCb = ConsolePrint,
+    };
+
+    for (i = 0; i < numMacPort; i++)
+    {
+        snprintf(&g_netdevices[i][0], CB_MAX_NETDEVNAME, "tilld%d", i);
+        appCfg.netdevs[i] = &g_netdevices[i][0];
+        ethdevs[i].netdev = g_netdevices[i];
+        ethdevs[i].macport = macPortList[i];
+        if (i == 0)
+        {
+            /* tilld0 reuses the allocated source mac, other interfaces will allocate
+             * the mac by themself */
+            EnetApp_getMacAddress(ENET_DMA_RX_CH0, &outArgs);
+            EnetAppUtils_assert(outArgs.macAddressCnt == 1);
+            memcpy(ethdevs[i].srcmac, &outArgs.macAddr[0][0], ENET_MAC_ADDR_LEN);
+        }
+    }
+    appCfg.netdevs[i] = NULL;
+    if (EnetApp_initTsnByCfg(&appCfg) < 0)
+    {
+        EnetAppAbort("Failed to int tsn!\r\n");
+    }
+    if (cb_lld_init_devs_table(ethdevs, i, enetType, instId) < 0)
+    {
+        EnetAppAbort("Failed to int devs table!\r\n");
+    }
+    cb_socket_set_lldcfg_update_cb(EnetApp_lldCfgUpdateCb);
+
+    if (EnetApp_startTsn() < 0)
+    {
+        EnetAppAbort("Failed to start TSN App!\r\n");
+    }
+    EnetAppUtils_print("%s:TSN app start done!\r\n", __func__);
+
+    return res;
+}

--- a/examples/netxduo/enet_netxduo_icssg_gptp/tsninit.c
+++ b/examples/netxduo/enet_netxduo_icssg_gptp/tsninit.c
@@ -1,0 +1,453 @@
+/*
+ *  Copyright (c) Texas Instruments Incorporated 2023
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* ========================================================================== */
+/*                              Include Files                                 */
+/* ========================================================================== */
+
+#include <tsn_combase/combase.h>
+#include <tsn_unibase/unibase_binding.h>
+#include <tsn_uniconf/yangs/yang_db_runtime.h>
+#include <tsn_uniconf/yangs/yang_modules.h>
+#include <tsn_gptp/gptpman.h>
+#include <tsn_gptp/tilld/lld_gptp_private.h>
+#include <tsn_gptp/gptpconf/gptpgcfg.h>
+#include <tsn_gptp/gptpconf/xl4-extmod-xl4gptp.h>
+#include <tsn_uniconf/yangs/ieee1588-ptp-tt_access.h>
+#include <tsn_uniconf/ucman.h>
+#include <tsn_uniconf/uc_dbal.h>
+#include "debug_log.h"
+#include "tsninit.h"
+#include "common.h"
+
+/* ========================================================================== */
+/*                           Macros & Typedefs                                */
+/* ========================================================================== */
+#define UNICONF_TASK_PRIORITY   (2)
+#define UNICONF_TASK_NAME       "uniconf_task"
+
+#ifndef TSNAPP_LOGLEVEL
+#define TSNAPP_LOGLEVEL "4,ubase:45,cbase:45,uconf:45,gptp:55m,lldp:45,avtp:45,nconf:45,xmrpd:45"
+#endif
+
+/* ========================================================================== */
+/*                          Function Declarations                             */
+/* ========================================================================== */
+static int EnetApp_initDb(void);
+static void *EnetApp_uniconfTask(void *arg);
+static int EnetApp_uniconfInit(EnetApp_ModuleCtx_t* modCtx, EnetApp_dbArgs *dbargs);
+static int EnetApp_startUniconfTask(void);
+static int EnetApp_startTask(EnetApp_ModuleCtx_t* modCtx, int moduleIdx);
+
+/* ========================================================================== */
+/*                     External Function Declarations                         */
+/* ========================================================================== */
+
+#ifdef NETCONF_ENABLED
+extern int EnetApp_addNetconfModCtx(EnetApp_ModuleCtx_t *modCtxTbl);
+#endif //NETCONF_ENABLED
+
+#ifdef AVTP_ENABLED
+extern int EnetApp_avtpInit(EnetApp_ModuleCtx_t *modCtxTbl);
+extern void EnetApp_avtpDeinit(void);
+#endif //AVTP_ENABLED
+
+#ifdef LLDP_ENABLED
+extern int EnetApp_addLldpModCtx(EnetApp_ModuleCtx_t *modCtxTbl);
+#endif //LLDP_ENABLED
+
+#ifdef GPTP_ENABLED
+extern int EnetApp_addGptpModCtx(EnetApp_ModuleCtx_t *modCtxTbl);
+#endif //GPTP_ENABLED
+
+#ifdef EST_APP_ENABLED
+extern int EnetApp_addEstAppModCtx(EnetApp_ModuleCtx_t *modCtxTbl);
+#endif /* EST_APP_ENABLED */
+
+#ifdef CBS_APP_ENABLED
+extern int EnetApp_addCbsAppModCtx(EnetApp_ModuleCtx_t *modCtxTbl);
+#endif /* EST_APP_ENABLED */
+
+#ifdef XMRPD_ENABLED
+extern int EnetApp_addMrpconfModCtx(EnetApp_ModuleCtx_t *modCtxTbl);
+#endif //XMRPD_ENABLED
+/* ========================================================================== */
+/*                            Global Variables                                */
+/* ========================================================================== */
+EnetApp_Ctx_t gAppCtx =
+{
+    .dbName = UNICONF_DBFILE_PATH,
+};
+EnetApp_ModuleCtx_t gModCtxTable[ENETAPP_MAX_TASK_IDX];
+
+/* ========================================================================== */
+/*                            Local Variables                                */
+/* ========================================================================== */
+static uint8_t gUniconfStackBuf[TSN_TSK_STACK_SIZE] \
+__attribute__ ((aligned(TSN_TSK_STACK_ALIGN)));
+
+/* ========================================================================== */
+/*                          Function Definitions                              */
+/* ========================================================================== */
+
+static void *EnetApp_uniconfTask(void *arg)
+{
+    EnetApp_ModuleCtx_t *modCtx = (EnetApp_ModuleCtx_t *)arg;
+    EnetApp_Ctx_t *appCtx = modCtx->appCtx;
+    const char *configFiles[2] = {INTERFACE_CONFFILE_PATH, NULL};
+
+    appCtx->ucCtx.ucmode = UC_CALLMODE_THREAD|UC_CALLMODE_UNICONF;
+    appCtx->ucCtx.stoprun = &modCtx->stopFlag;
+    appCtx->ucCtx.hwmod="";
+    appCtx->ucCtx.ucmanstart = &appCtx->ucReadySem;
+    appCtx->ucCtx.dbname = appCtx->dbName;
+    appCtx->ucCtx.configfiles = configFiles;
+    appCtx->ucCtx.numconfigfile = UNICONF_CONF_FILE_NUM;
+
+    DPRINT("%s: dbname: %s", __func__, appCtx->dbName ? appCtx->dbName : "NULL");
+
+    return uniconf_main(&appCtx->ucCtx);
+}
+
+static int EnetApp_uniconfInit(EnetApp_ModuleCtx_t* modCtx, EnetApp_dbArgs *dbargs)
+{
+#ifdef DISABLE_FAT_FS
+    EnetApp_Ctx_t *appCtx = modCtx->appCtx;
+    char buffer[MAX_KEY_SIZE]={0};
+    int res=-1;
+    int i;
+
+    for (i = 0; i < appCtx->netdevSize; i++)
+    {
+        snprintf(buffer, sizeof(buffer),
+                 "/ietf-interfaces/interfaces/interface|name:%s|/enabled",
+                 appCtx->netdev[i]);
+        res=yang_db_runtime_put_oneline(dbargs->ydrd, buffer, (char*)"true",
+                                        YANG_DB_ONHW_NOACTION);
+        if (res != 0) {
+            DPRINT("%s: yang_db_runtime_put_oneline failed=%d", __func__, res);
+        }
+    }
+    return res;
+#else
+    TSNAPP_UNUSED_ARG(dbargs);
+    return 0;
+#endif
+}
+
+// Can be read from cfg files, or in case of no db file is specified, init runtime config
+static int EnetApp_initDb(void)
+{
+    EnetApp_ModuleCtx_t *mod;
+    EnetApp_dbArgs dbargs;
+    int res = 0;
+    int timeout_ms = 500;
+    int i;
+
+    do {
+        res = CB_SEM_WAIT(&gAppCtx.ucReadySem);
+        if (res != 0)
+        {
+            DPRINT("Failed to wait for the uniconf \n");
+            break;
+        }
+
+        res = uniconf_ready(gAppCtx.dbName, UC_CALLMODE_THREAD, timeout_ms);
+        if (res)
+        {
+            DPRINT("The uniconf must be run first !");
+            break;
+        }
+        dbargs.dbald = uc_dbal_open(gAppCtx.dbName, "w", UC_CALLMODE_THREAD);
+        if (!dbargs.dbald)
+        {
+            DPRINT("Failed to open DB!");
+            res = -1;
+            break;
+        }
+        dbargs.ydrd = yang_db_runtime_init(dbargs.dbald, NULL);
+        if (!dbargs.ydrd)
+        {
+            DPRINT("Failed to init yang db runtime");
+            res = -1;
+            break;
+        }
+
+        for (i = 0; i < ENETAPP_MAX_TASK_IDX; i++)
+        {
+            mod = &gModCtxTable[i];
+            if ((mod->enable == BTRUE) && (mod->onModuleDBInit != NULL))
+            {
+                mod->onModuleDBInit(mod, &dbargs);
+            }
+        }
+
+    } while (0);
+    if (dbargs.ydrd)
+    {
+        yang_db_runtime_close(dbargs.ydrd);
+    }
+    if (dbargs.dbald)
+    {
+        uc_dbal_close(dbargs.dbald, UC_CALLMODE_THREAD);
+    }
+
+    return res;
+}
+
+static bool EnetApp_isDBFileInit(char *filename)
+{
+#ifndef DISABLE_FAT_FS
+    EnetApp_fsInfo_t fsInfo;
+    return (FSTAT(filename, &fsInfo) == FSSTAT_OK);
+#else
+    return BFALSE;
+#endif /* !DISABLE_FAT_FS */
+}
+
+int EnetApp_initTsnByCfg(AppTsnCfg_t *cfg)
+{
+    int i = 0;
+    int res = 0;
+    unibase_init_para_t initPara;
+    EnetApp_ModuleCtx_t uniconfModCtx = {
+        .enable = BTRUE,
+        .stopFlag = BTRUE,
+        .taskPriority = UNICONF_TASK_PRIORITY,
+        .taskName = UNICONF_TASK_NAME,
+        .stackBuffer = gUniconfStackBuf,
+        .stackSize = sizeof(gUniconfStackBuf),
+        .onModuleDBInit = EnetApp_uniconfInit,
+        .onModuleRunner = EnetApp_uniconfTask,
+        .appCtx = &gAppCtx
+    };
+
+    Logger_init(cfg->consoleOutCb);
+
+    ubb_default_initpara(&initPara);
+
+    initPara.ub_log_initstr = TSNAPP_LOGLEVEL;
+    if (cfg->consoleOutCb)
+    {
+        initPara.cbset.console_out=LOG_OUTPUT;
+    }
+
+    unibase_init(&initPara);
+    ubb_memory_out_init(NULL, 0);
+
+    while (cfg->netdevs[i] != NULL && i < MAX_NUMBER_ENET_DEVS)
+    {
+        if (strlen(cfg->netdevs[i]) < CB_MAX_NETDEVNAME)
+        {
+            strcpy(&gAppCtx.netdev[gAppCtx.netdevSize][0],
+                   cfg->netdevs[i]);
+            gAppCtx.netdevSize++;
+        }
+        i++;
+    }
+
+    if (gAppCtx.dbName != NULL)
+    {
+        /* set DB File initialized flag to be used later during onModuleDBInit */
+        gAppCtx.dbInitFlag = EnetApp_isDBFileInit(gAppCtx.dbName);
+        DPRINT("DB File Initialized: %s", gAppCtx.dbInitFlag ? "True" : "False");
+    }
+
+    if (CB_SEM_INIT(&gAppCtx.ucReadySem, 0, 0) < 0)
+    {
+        DPRINT("Failed to initialize ucReadySem semaphore!");
+        res = -1;
+    }
+
+    memcpy(&gModCtxTable[ENETAPP_UNICONF_TASK_IDX],
+           &uniconfModCtx, sizeof(EnetApp_ModuleCtx_t));
+
+#ifdef GPTP_ENABLED
+    if (res == 0)
+    {
+        res = EnetApp_addGptpModCtx(gModCtxTable);
+    }
+#endif //GPTP_ENABLED
+
+#ifdef LLDP_ENABLED
+    if (res == 0)
+    {
+        res = EnetApp_addLldpModCtx(gModCtxTable);
+    }
+#endif //LLDP_ENABLED
+
+#ifdef AVTP_ENABLED
+    if (res == 0)
+    {
+        res = EnetApp_avtpInit(gModCtxTable);
+    }
+#endif //AVTP_ENABLED
+
+#ifdef NETCONF_ENABLED
+    if (res == 0)
+    {
+        res = EnetApp_addNetconfModCtx(gModCtxTable);
+    }
+#endif //NETCONF_ENABLED
+
+#ifdef EST_APP_ENABLED
+    if (res == 0)
+    {
+        res = EnetApp_addEstAppModCtx(gModCtxTable);
+    }
+#endif //EST_APP_ENABLED
+
+#ifdef CBS_APP_ENABLED
+    if (res == 0)
+    {
+        res = EnetApp_addCbsAppModCtx(gModCtxTable);
+    }
+#endif //CBS_APP_ENABLED
+
+#ifdef XMRPD_ENABLED
+    if (res == 0)
+    {
+        res = EnetApp_addMrpconfModCtx(gModCtxTable);
+    }
+#endif //XMRPD_ENABLED
+    return res;
+}
+
+void EnetApp_deInitTsn(void)
+{
+#ifdef AVTP_ENABLED
+    EnetApp_avtpDeinit();
+#endif //AVTP_ENABLED
+    if (gAppCtx.ucReadySem != NULL)
+    {
+        CB_SEM_DESTROY(&gAppCtx.ucReadySem);
+        gAppCtx.ucReadySem = NULL;
+    }
+    memset(&gAppCtx, 0, sizeof(gAppCtx));
+    memset(gModCtxTable, 0, sizeof(gModCtxTable));
+
+    Logger_deInit();
+    unibase_close();
+}
+
+static int EnetApp_startTask(EnetApp_ModuleCtx_t *modCtx, int moduleIdx)
+{
+    cb_tsn_thread_attr_t attr;
+    int res = 0;
+
+    modCtx->stopFlag = BFALSE;
+    cb_tsn_thread_attr_init(&attr, modCtx->taskPriority,
+                            modCtx->stackSize, modCtx->taskName);
+    cb_tsn_thread_attr_set_stackaddr(&attr, modCtx->stackBuffer);
+    if (CB_THREAD_CREATE(&modCtx->hTaskHandle,
+                         &attr, modCtx->onModuleRunner, modCtx) < 0)
+    {
+        modCtx->stopFlag = BTRUE;
+        DPRINT("Failed to start %s !", modCtx->taskName);
+        res = -1;
+    }
+    else
+    {
+        DPRINT("Start: %s", modCtx->taskName);
+        if (moduleIdx == ENETAPP_UNICONF_TASK_IDX)
+        {
+            /* initDb must be run right after UNICONF is started and
+             * before starting any other tasks. */
+            res = EnetApp_initDb();
+        }
+    }
+    return res;
+}
+
+int EnetApp_startTsn(void)
+{
+    int i;
+    int res = 0;
+
+    for (i = 0; i < ENETAPP_MAX_TASK_IDX; i++)
+    {
+        res = EnetApp_startTsnModule(i);
+        if (res != 0)
+        {
+            break;
+        }
+    }
+    return res;
+}
+
+void EnetApp_stopTsn(void)
+{
+    int i;
+
+    /* The uniconf with index = 0 must be stopped finally */
+    for (i = ENETAPP_MAX_TASK_IDX-1; i >= 0; i--)
+    {
+        EnetApp_stopTsnModule(i);
+    }
+}
+
+int EnetApp_startTsnModule(int moduleIdx)
+{
+    int res = 0;
+
+    if ((moduleIdx >= 0) && (moduleIdx < ENETAPP_MAX_TASK_IDX))
+    {
+        EnetApp_ModuleCtx_t *mod;
+        mod = &gModCtxTable[moduleIdx];
+
+        if ((mod->enable == BTRUE) && (mod->stopFlag == BTRUE))
+        {
+            res = EnetApp_startTask(mod, moduleIdx);
+        }
+    }
+    else
+    {
+        res = -1;
+    }
+    return res;
+}
+
+void EnetApp_stopTsnModule(int moduleIdx)
+{
+    if ((moduleIdx >= 0) && (moduleIdx < ENETAPP_MAX_TASK_IDX))
+    {
+        EnetApp_ModuleCtx_t *mod;
+        mod = &gModCtxTable[moduleIdx];
+        if (mod->hTaskHandle != NULL)
+        {
+            mod->stopFlag = BTRUE;
+            CB_THREAD_JOIN(mod->hTaskHandle, NULL);
+            mod->hTaskHandle = NULL;
+            DPRINT("Task: %s is terminated.", mod->taskName);
+        }
+    }
+}

--- a/examples/netxduo/enet_netxduo_icssg_iperf/.project/project.js
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/.project/project.js
@@ -1,0 +1,14 @@
+function getComponentProperty(device)
+{
+    return require(`./project_${device}`).getComponentProperty();
+};
+
+function getComponentBuildProperty(buildOption)
+{
+    return require(`./project_${buildOption.device}`).getComponentBuildProperty(buildOption);
+};
+
+module.exports = {
+    getComponentProperty,
+    getComponentBuildProperty,
+};

--- a/examples/netxduo/enet_netxduo_icssg_iperf/.project/project_am243x.js
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/.project/project_am243x.js
@@ -1,0 +1,200 @@
+let path = require('path');
+
+let device = "am243x";
+
+const files = {
+    common: [
+        "netxduo_icssg.c",
+        "enet_icssg_link.c",
+        "main.c",
+    ],
+};
+
+/* Relative to where the makefile will be generated
+ * Typically at <example_folder>/<BOARD>/<core_os_combo>/<compiler>
+ */
+const filedirs = {
+    common: [
+        "..",       /* core_os_combo base */
+        "../../..", /* Example base */
+    ],
+};
+
+const libdirs = {
+    common: [
+        "generated",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/lib",
+        "${MCU_PLUS_SDK_PATH}/source/fs/filex/lib",
+        "${MCU_PLUS_SDK_PATH}/source/kernel/threadx/lib",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/lib",
+        "${MCU_PLUS_SDK_PATH}/source/drivers/lib",
+        "${MCU_PLUS_SDK_PATH}/source/board/lib",
+    ],
+};
+
+const includes = {
+    common: [
+        "${MCU_PLUS_SDK_PATH}/source/board/ethphy/enet/rtos_drivers/include",
+        "${MCU_PLUS_SDK_PATH}/source/board/ethphy/port",
+        "${MCU_PLUS_SDK_PATH}/source/kernel/threadx/threadx_src/common/inc",
+        "${MCU_PLUS_SDK_PATH}/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/inc",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/ports/cortex_r5/gnu/inc/",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/utils/include",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/utils/V3",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/core",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/phy",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/core",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/soc/k3/am64x_am243x",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include",
+        "${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include/mdio/V4",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ftp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/http",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mdns",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mqtt",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/nat",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/snmp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/sntp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/telnet",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/tftp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/web",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/websocket",
+    ],
+};
+
+const libs = {
+    common: [
+        "threadx.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+        "netxduo.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+        "filex.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+        "enet-icssg.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+        "drivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+        "board.am243x.r5f.ti-arm-clang.${ConfigName}.lib",
+    ],
+};
+
+const projectspec_linker_path = {
+    common: [
+        "${PROJECT_BUILD_DIR}/syscfg",
+
+    ],
+};
+
+const defines_r5f = {
+    common: [
+        "NX_INCLUDE_USER_DEFINE_FILE",
+        "ENET_ENABLE_PER_ICSSG=1",
+    ],
+};
+
+const cflags_r5f = {
+    common: [
+    ],
+    release: [
+        "-Oz",
+        "-flto",
+    ],
+};
+
+const lflags_r5f = {
+    common: [
+        "--zero_init=on",
+        "--use_memset=fast",
+        "--use_memcpy=fast"
+    ],
+};
+
+const loptflags_r5f = {
+    release: [
+        "-mcpu=cortex-r5",
+        "-mfloat-abi=hard",
+        "-mfpu=vfpv3-d16",
+        "-mthumb",
+        "-Oz",
+        "-flto"
+    ],
+};
+
+const lnkfiles = {
+    common: [
+        "../linker.cmd",
+    ]
+};
+
+const syscfgfile = "../example.syscfg";
+
+const readmeDoxygenPageTag = "EXAMPLES_ECLIPSE_THREADX_NETXDUO_ICSSG_IPERF";
+
+
+const templates_r5f =
+[
+    {
+        input: ".project/templates/am243x/threadx/main_threadx.c.xdt",
+        output: "../main.c",
+        options: {
+            entryFunction: "netxduo_icssg_main",
+        },
+    }
+];
+
+const buildOptionCombos = [
+    { device: device, cpu: "r5fss0-0", cgt: "ti-arm-clang", board: "am243x-evm", os: "threadx"},
+    { device: device, cpu: "r5fss0-0", cgt: "ti-arm-clang", board: "am243x-lp", os: "threadx"},
+];
+
+function getComponentProperty() {
+    let property = {};
+
+    property.dirPath = path.resolve(__dirname, "..");
+    property.type = "executable";
+    property.name = "enet_netxduo_icssg_iperf";
+    property.isInternal = false;
+    property.tirexResourceSubClass = [ "example.gettingstarted" ];
+    property.description = "A NetxDuo Iperf example for the CPSW."
+    property.buildOptionCombos = buildOptionCombos;
+
+    return property;
+}
+
+function getComponentBuildProperty(buildOption) {
+    let build_property = {};
+
+    build_property.files = files;
+    build_property.filedirs = filedirs;
+    build_property.libdirs = libdirs;
+    build_property.lnkfiles = lnkfiles;
+    build_property.syscfgfile = syscfgfile;
+    build_property.readmeDoxygenPageTag = readmeDoxygenPageTag;
+    build_property.includes = includes;
+    build_property.templates = templates_r5f;
+    build_property.projecspecFileAction = "link";
+    build_property.libs = libs;
+    build_property.cflags = cflags_r5f;
+    build_property.lflags = lflags_r5f;
+    build_property.loptflags = loptflags_r5f;
+    build_property.defines = defines_r5f;
+    build_property.projectspecLnkPath = projectspec_linker_path;
+
+    return build_property;
+}
+
+module.exports = {
+    getComponentProperty,
+    getComponentBuildProperty,
+};

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/example.syscfg
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/example.syscfg
@@ -1,0 +1,208 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM243x_ALV_beta" --part "ALV" --package "ALV" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM2434" --package "FCBGA (ALV)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.21.2+3837"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const eeprom     = scripting.addModule("/board/eeprom/eeprom", {}, false);
+const eeprom1    = eeprom.addInstance();
+const gpio       = scripting.addModule("/drivers/gpio/gpio", {}, false);
+const gpio1      = gpio.addInstance();
+const i2c        = scripting.addModule("/drivers/i2c/i2c", {}, false);
+const i2c1       = i2c.addInstance();
+const i2c2       = i2c.addInstance();
+const pruicss    = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1   = pruicss.addInstance();
+const debug_log  = scripting.addModule("/kernel/dpl/debug_log");
+const mpu_armv7  = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71 = mpu_armv7.addInstance();
+const mpu_armv72 = mpu_armv7.addInstance();
+const mpu_armv73 = mpu_armv7.addInstance();
+const mpu_armv74 = mpu_armv7.addInstance();
+const mpu_armv75 = mpu_armv7.addInstance();
+const mpu_armv76 = mpu_armv7.addInstance();
+const mpu_armv77 = mpu_armv7.addInstance();
+const enet_icss  = scripting.addModule("/networking/enet_icss/enet_icss", {}, false);
+const enet_icss1 = enet_icss.addInstance();
+const enet_icss2 = enet_icss.addInstance();
+const netxduo    = scripting.addModule("/networking/netxduo/netxduo", {}, false);
+const netxduo1   = netxduo.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+eeprom1.$name = "CONFIG_EEPROM0";
+
+gpio1.$name                    = "CONFIG_GPIO0";
+gpio1.pinDir                   = "OUTPUT";
+gpio1.useMcuDomainPeripherals  = true;
+gpio1.MCU_GPIO.$assign         = "MCU_GPIO0";
+gpio1.MCU_GPIO.gpioPin.$assign = "MCU_SPI1_CS0";
+
+i2c1.$name               = "CONFIG_I2C0";
+eeprom1.peripheralDriver = i2c1;
+i2c1.I2C.$assign         = "I2C0";
+i2c1.I2C.SCL.$assign     = "I2C0_SCL";
+i2c1.I2C.SDA.$assign     = "I2C0_SDA";
+i2c1.I2C_child.$name     = "drivers_i2c_v0_i2c_v0_template1";
+
+i2c2.$name           = "CONFIG_I2C1";
+i2c2.I2C.$assign     = "I2C1";
+i2c2.I2C.SCL.$assign = "I2C1_SCL";
+i2c2.I2C.SDA.$assign = "I2C1_SDA";
+i2c2.I2C_child.$name = "drivers_i2c_v0_i2c_v0_template2";
+
+debug_log.enableUartLog = true;
+debug_log.enableCssLog  = false;
+debug_log.uartLog.$name = "CONFIG_UART0";
+
+const uart_v0_template  = scripting.addModule("/drivers/uart/v0/uart_v0_template", {}, false);
+const uart_v0_template1 = uart_v0_template.addInstance({}, false);
+uart_v0_template1.$name = "drivers_uart_v0_uart_v0_template0";
+debug_log.uartLog.child = uart_v0_template1;
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 23;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION4";
+mpu_armv75.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv75.baseAddr          = 0x80000000;
+mpu_armv75.size              = 31;
+
+mpu_armv76.$name             = "CONFIG_MPU_REGION5";
+mpu_armv76.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv76.baseAddr          = 0xA5000000;
+mpu_armv76.size              = 23;
+mpu_armv76.attributes        = "NonCached";
+
+mpu_armv77.$name    = "CONFIG_MPU_REGION6";
+mpu_armv77.size     = 27;
+mpu_armv77.baseAddr = 0x60000000;
+
+enet_icss1.$name                        = "CONFIG_ENET_ICSS0";
+enet_icss1.phyToMacInterfaceMode        = "RGMII";
+enet_icss1.mdioMode                     = "MDIO_MODE_MANUAL";
+enet_icss1.PktInfoOnlyEnable            = true;
+enet_icss1.QoS                          = 3;
+enet_icss1.mode                         = "DUAL MAC";
+enet_icss1.PktPoolEnable                = false;
+enet_icss1.PktInfoOnlyCount             = 96;
+enet_icss1.txDmaChannel[0].$name        = "ENET_DMA_TX_CH0";
+enet_icss1.txDmaChannel[0].PacketsCount = 64;
+enet_icss1.PRU_ICSSG1_RGMII1.$assign    = "PRU_ICSSG1_RGMII1";
+enet_icss1.rxDmaChannel[0].$name        = "ENET_DMA_RX_CH0";
+enet_icss1.rxDmaChannel[0].useGlobalEvt = false;
+enet_icss1.rxDmaChannel[0].sizeThreshEn = 0;
+
+const ethphy_cpsw_icssg  = scripting.addModule("/board/ethphy_cpsw_icssg/ethphy_cpsw_icssg", {}, false);
+const ethphy_cpsw_icssg1 = ethphy_cpsw_icssg.addInstance({}, false);
+ethphy_cpsw_icssg1.$name = "CONFIG_ENET_ETHPHY0";
+enet_icss1.ethphy2       = ethphy_cpsw_icssg1;
+
+enet_icss2.$name                        = "CONFIG_ENET_ICSS1";
+enet_icss2.mode                         = "DUAL MAC";
+enet_icss2.dualMacPortSelected          = "ENET_MAC_PORT_2";
+enet_icss2.mdioMdcEnable                = false;
+enet_icss2.QoS                          = 3;
+enet_icss2.phyToMacInterfaceMode        = "RGMII";
+enet_icss2.PktPoolEnable                = false;
+enet_icss2.PktInfoOnlyEnable            = true;
+enet_icss2.PktInfoOnlyCount             = 32;
+enet_icss2.txDmaChannel[0].$name        = "ENET_DMA_TX_CH1";
+enet_icss2.rxDmaChannel[0].$name        = "ENET_DMA_RX_CH2";
+enet_icss2.rxDmaChannel[0].useGlobalEvt = false;
+enet_icss2.rxDmaChannel[0].sizeThreshEn = 0;
+enet_icss2.rxDmaChannel[0].PacketsCount = 16;
+
+const ethphy_cpsw_icssg2 = ethphy_cpsw_icssg.addInstance({}, false);
+ethphy_cpsw_icssg2.$name = "CONFIG_ENET_ETHPHY1";
+enet_icss2.ethphy3       = ethphy_cpsw_icssg2;
+
+enet_icss1.icss                          = pruicss1;
+pruicss1.$name                           = "CONFIG_PRU_ICSS1";
+enet_icss2.icss                          = pruicss1;
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+pruicss1.intcMapping.create(2);
+pruicss1.intcMapping[0].$name            = "CONFIG_ICSS1_INTC_MAPPING0";
+pruicss1.intcMapping[0].event            = "41";
+pruicss1.intcMapping[0].channel          = "7";
+pruicss1.intcMapping[0].host             = "8";
+pruicss1.intcMapping[1].$name            = "CONFIG_ICSS1_INTC_MAPPING1";
+pruicss1.intcMapping[1].event            = "53";
+pruicss1.intcMapping[1].channel          = "7";
+pruicss1.intcMapping[1].host             = "8";
+
+const udma         = scripting.addModule("/drivers/udma/udma", {}, false);
+const udma1        = udma.addInstance({}, false);
+enet_icss1.udmaDrv = udma1;
+enet_icss2.udmaDrv = udma1;
+
+netxduo1.$name                                   = "CONFIG_NETXDUO0";
+netxduo1.netxduoIfInstance.create(2);
+netxduo1.netxduoIfInstance[0].$name              = "CONFIG_NETX_IF0";
+netxduo1.netxduoIfInstance[0].enet_instance_name = "CONFIG_ENET_ICSS0";
+netxduo1.netxduoIfInstance[0].isDefault          = true;
+netxduo1.netxduoIfInstance[1].$name              = "CONFIG_NETX_IF1";
+netxduo1.netxduoIfInstance[1].enet_instance_name = "CONFIG_ENET_ICSS1";
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.UART.$suggestSolution                  = "USART0";
+debug_log.uartLog.UART.RXD.$suggestSolution              = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$suggestSolution              = "UART0_TXD";
+enet_icss1.PRU_ICSSG1_MDIO.$suggestSolution              = "PRU_ICSSG1_MDIO0";
+enet_icss1.PRU_ICSSG1_MDIO.MDC.$suggestSolution          = "PRG1_MDIO0_MDC";
+enet_icss1.PRU_ICSSG1_MDIO.MDIO.$suggestSolution         = "PRG1_MDIO0_MDIO";
+enet_icss1.PRU_ICSSG1_IEP.$suggestSolution               = "PRU_ICSSG1_IEP0";
+enet_icss1.PRU_ICSSG1_IEP.EDC_LATCH_IN0.$suggestSolution = "PRG1_PRU0_GPO18";
+enet_icss1.PRU_ICSSG1_IEP.EDC_SYNC_OUT0.$suggestSolution = "PRG1_PRU0_GPO19";
+enet_icss1.PRU_ICSSG1_RGMII1.RD0.$suggestSolution        = "PRG1_PRU0_GPO0";
+enet_icss1.PRU_ICSSG1_RGMII1.RD1.$suggestSolution        = "PRG1_PRU0_GPO1";
+enet_icss1.PRU_ICSSG1_RGMII1.RD2.$suggestSolution        = "PRG1_PRU0_GPO2";
+enet_icss1.PRU_ICSSG1_RGMII1.RD3.$suggestSolution        = "PRG1_PRU0_GPO3";
+enet_icss1.PRU_ICSSG1_RGMII1.RXC.$suggestSolution        = "PRG1_PRU0_GPO6";
+enet_icss1.PRU_ICSSG1_RGMII1.RX_CTL.$suggestSolution     = "PRG1_PRU0_GPO4";
+enet_icss1.PRU_ICSSG1_RGMII1.TD0.$suggestSolution        = "PRG1_PRU0_GPO11";
+enet_icss1.PRU_ICSSG1_RGMII1.TD1.$suggestSolution        = "PRG1_PRU0_GPO12";
+enet_icss1.PRU_ICSSG1_RGMII1.TD2.$suggestSolution        = "PRG1_PRU0_GPO13";
+enet_icss1.PRU_ICSSG1_RGMII1.TD3.$suggestSolution        = "PRG1_PRU0_GPO14";
+enet_icss1.PRU_ICSSG1_RGMII1.TXC.$suggestSolution        = "PRG1_PRU0_GPO16";
+enet_icss1.PRU_ICSSG1_RGMII1.TX_CTL.$suggestSolution     = "PRG1_PRU0_GPO15";
+enet_icss2.PRU_ICSSG1_RGMII2.$suggestSolution            = "PRU_ICSSG1_RGMII2";
+enet_icss2.PRU_ICSSG1_RGMII2.RD0.$suggestSolution        = "PRG1_PRU1_GPO0";
+enet_icss2.PRU_ICSSG1_RGMII2.RD1.$suggestSolution        = "PRG1_PRU1_GPO1";
+enet_icss2.PRU_ICSSG1_RGMII2.RD2.$suggestSolution        = "PRG1_PRU1_GPO2";
+enet_icss2.PRU_ICSSG1_RGMII2.RD3.$suggestSolution        = "PRG1_PRU1_GPO3";
+enet_icss2.PRU_ICSSG1_RGMII2.RXC.$suggestSolution        = "PRG1_PRU1_GPO6";
+enet_icss2.PRU_ICSSG1_RGMII2.RX_CTL.$suggestSolution     = "PRG1_PRU1_GPO4";
+enet_icss2.PRU_ICSSG1_RGMII2.TD0.$suggestSolution        = "PRG1_PRU1_GPO11";
+enet_icss2.PRU_ICSSG1_RGMII2.TD1.$suggestSolution        = "PRG1_PRU1_GPO12";
+enet_icss2.PRU_ICSSG1_RGMII2.TD2.$suggestSolution        = "PRG1_PRU1_GPO13";
+enet_icss2.PRU_ICSSG1_RGMII2.TD3.$suggestSolution        = "PRG1_PRU1_GPO14";
+enet_icss2.PRU_ICSSG1_RGMII2.TXC.$suggestSolution        = "PRG1_PRU1_GPO16";
+enet_icss2.PRU_ICSSG1_RGMII2.TX_CTL.$suggestSolution     = "PRG1_PRU1_GPO15";

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/main.c
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2018-2024 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include <tx_api.h>
+
+
+#define MAIN_TASK_PRI  (4)
+
+#define MAIN_TASK_STACK_SIZE (8192U)
+
+uint8_t main_thread_stack[MAIN_TASK_STACK_SIZE] __attribute__((aligned(32)));
+
+TX_THREAD main_thread;
+
+void netxduo_icssg_main(void *args);
+
+void threadx_main(ULONG arg)
+{
+    netxduo_icssg_main(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* Enter the ThreadX kernel.  */
+    tx_kernel_enter();
+}
+
+void tx_application_define(void *first_unused_memory)
+{
+    UINT status;
+
+    status = tx_thread_create(&main_thread,           /* Pointer to the main thread object. */ 
+                              "main_thread",          /* Name of the task for debugging purposes. */
+                              threadx_main,           /* Entry function for the main thread. */
+                              0,                      /* Arguments passed to the entry function. */  
+                              main_thread_stack,      /* Main thread stack. */
+                              MAIN_TASK_STACK_SIZE,   /* Main thread stack size in bytes. */
+                              MAIN_TASK_PRI,          /* Main task priority. */
+                              MAIN_TASK_PRI,          /* Highest priority level of disabled preemption. */
+                              TX_NO_TIME_SLICE,       /* No time slice. */
+                              TX_AUTO_START);         /* Start immediately. */
+
+    DebugP_assertNoLog(status == TX_SUCCESS);
+}
+
+

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/ti-arm-clang/example.projectspec
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/ti-arm-clang/example.projectspec
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM2434_ALV"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Enet Netxduo Icssg Iperf"
+        name = "enet_netxduo_icssg_iperf_am243x-evm_r5fss0-0_threadx_ti-arm-clang"
+        products="sysconfig;com.ti.MCU_PLUS_SDK_AMXXX"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.1"
+        device="Cortex R.AM2434_ALV"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/board/ethphy/enet/rtos_drivers/include
+            -I${MCU_PLUS_SDK_PATH}/source/board/ethphy/port
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/threadx_src/common/inc
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/inc
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/ports/cortex_r5/gnu/inc/
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/utils/include
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/utils/V3
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/phy
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/core
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/soc/k3/am64x_am243x
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include/mdio/V4
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ftp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/http
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mdns
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mqtt
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/nat
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/snmp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/sntp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/telnet
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/tftp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/web
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/websocket
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM243X
+            -DNX_INCLUDE_USER_DEFINE_FILE
+            -DENET_ENABLE_PER_ICSSG=1
+        "
+        linkerBuildOptions="
+            -igenerated
+            -i${MCU_PLUS_SDK_PATH}/source/networking/netxduo/lib
+            -i${MCU_PLUS_SDK_PATH}/source/fs/filex/lib
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/threadx/lib
+            -i${MCU_PLUS_SDK_PATH}/source/networking/enet/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${CG_TOOL_ROOT}/lib
+            -i${PROJECT_BUILD_DIR}/syscfg
+            -m=enet_netxduo_icssg_iperf.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+            --gen_xml_func_hash
+            --zero_init=on
+            --use_memset=fast
+            --use_memcpy=fast
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am243x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part ALV --package ALV
+        "
+
+        description="A Enet Netxduo Icssg Iperf THREADX project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lthreadx.am243x.r5f.ti-arm-clang.debug.lib
+                -lnetxduo.am243x.r5f.ti-arm-clang.debug.lib
+                -lfilex.am243x.r5f.ti-arm-clang.debug.lib
+                -lenet-icssg.am243x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.debug.lib
+                -lboard.am243x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+                -Oz
+                -flto
+            "
+            linkerBuildOptions="
+                -lthreadx.am243x.r5f.ti-arm-clang.release.lib
+                -lnetxduo.am243x.r5f.ti-arm-clang.release.lib
+                -lfilex.am243x.r5f.ti-arm-clang.release.lib
+                -lenet-icssg.am243x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.release.lib
+                -lboard.am243x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AMXXX_INSTALL_DIR}" scope="project" />
+        <file path="../../../netxduo_icssg.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../../../enet_icssg_link.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="linker.cmd" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="${MCU_PLUS_SDK_PATH}/docs/api_guide_am243x/EXAMPLES_ECLIPSE_THREADX_NETXDUO_ICSSG_IPERF.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/ti-arm-clang/linker.cmd
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/ti-arm-clang/linker.cmd
@@ -1,0 +1,238 @@
+#include "ti_enet_config.h"
+
+/* This is the stack that is used by code running within main()
+ * In case of NORTOS,
+ * - This means all the code outside of ISR uses this stack
+ * In case of FreeRTOS
+ * - This means all the code until vTaskStartScheduler() is called in main()
+ *   uses this stack.
+ * - After vTaskStartScheduler() each task created in FreeRTOS has its own stack
+ */
+--stack_size=8192
+/* This is the heap size for malloc() API in NORTOS and FreeRTOS
+ * This is also the heap used by pvPortMalloc in FreeRTOS
+ */
+--heap_size=34000
+-e_vectors  /* This is the entry of the application, _vector MUST be plabed starting address 0x0 */
+
+/* This is the size of stack when R5 is in IRQ mode
+ * In NORTOS,
+ * - Here interrupt nesting is disabled as of now
+ * - This is the stack used by ISRs registered as type IRQ
+ * In FreeRTOS,
+ * - Here interrupt nesting is enabled
+ * - This is stack that is used initally when a IRQ is received
+ * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
+ * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
+ */
+__IRQ_STACK_SIZE = 256;
+/* This is the size of stack when R5 is in IRQ mode
+ * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
+ */
+__FIQ_STACK_SIZE = 256;
+__SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
+__ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
+__UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */
+
+SECTIONS
+{
+    /* This has the R5F entry point and vector table, this MUST be at 0x0 */
+    .vectors:{} palign(8) > R5F_VECS
+
+    /* This has the R5F boot code until MPU is enabled,  this MUST be at a address < 0x80000000
+     * i.e this cannot be placed in DDR
+     */
+    GROUP {
+        .text.hwi: palign(8)
+        .text.cache: palign(8)
+        .text.mpu: palign(8)
+        .text.boot: palign(8)
+        .text:abort: palign(8) /* this helps in loading symbols when using XIP mode */
+    } > MSRAM
+
+    UNION:
+    {
+        .icssfw : palign(128)
+        .icss_mem: type = NOLOAD {
+#if (ENET_SYSCFG_ICSSG0_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 1)
+        #if(ENET_SYSCFG_DUALMAC_PORT1_ENABLED == 1)
+            *(*gEnetSoc_icssg0HostPoolMem_0)
+            *(*gEnetSoc_icssg0HostQueueMem_0)
+            *(*gEnetSoc_icssg0ScratchMem_0)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                *(*gEnetSoc_icssg0HostPreQueueMem_0)
+            #endif
+        #else
+            *(*gEnetSoc_icssg0HostPoolMem_1)
+            *(*gEnetSoc_icssg0HostQueueMem_1)
+            *(*gEnetSoc_icssg0ScratchMem_1)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                    *(*gEnetSoc_icssg0HostPreQueueMem_1)
+            #endif
+        #endif
+    #endif
+#endif
+#if (ENET_SYSCFG_ICSSG1_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 1)
+        #if(ENET_SYSCFG_DUALMAC_PORT1_ENABLED == 1)
+                *(*gEnetSoc_icssg1HostPoolMem_0)
+                *(*gEnetSoc_icssg1HostQueueMem_0)
+                *(*gEnetSoc_icssg1ScratchMem_0)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                *(*gEnetSoc_icssg1HostPreQueueMem_0)
+            #endif
+        #else
+                *(*gEnetSoc_icssg1HostPoolMem_1)
+                *(*gEnetSoc_icssg1HostQueueMem_1)
+                *(*gEnetSoc_icssg1ScratchMem_1)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                *(*gEnetSoc_icssg1HostPreQueueMem_1)
+            #endif
+        #endif
+    #endif
+#endif
+#if (ENET_SYSCFG_ICSSG0_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 0)
+        *(*gEnetSoc_icssg0PortPoolMem_0)
+        *(*gEnetSoc_icssg0PortPoolMem_1)
+        *(*gEnetSoc_icssg0HostPoolMem_0)
+        *(*gEnetSoc_icssg0HostPoolMem_1)
+        *(*gEnetSoc_icssg0HostQueueMem_0)
+        *(*gEnetSoc_icssg0HostQueueMem_1)
+        *(*gEnetSoc_icssg0ScratchMem_0)
+        *(*gEnetSoc_icssg0ScratchMem_1)
+        #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+            *(*gEnetSoc_icssg0HostPreQueueMem_0)
+            *(*gEnetSoc_icssg0HostPreQueueMem_1)
+        #endif
+    #endif
+#endif
+#if (ENET_SYSCFG_ICSSG1_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 0)
+        *(*gEnetSoc_icssg1PortPoolMem_0)
+        *(*gEnetSoc_icssg1PortPoolMem_1)
+        *(*gEnetSoc_icssg1HostPoolMem_0)
+        *(*gEnetSoc_icssg1HostPoolMem_1)
+        *(*gEnetSoc_icssg1HostQueueMem_0)
+        *(*gEnetSoc_icssg1HostQueueMem_1)
+        *(*gEnetSoc_icssg1ScratchMem_0)
+        *(*gEnetSoc_icssg1ScratchMem_1)
+        #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+            *(*gEnetSoc_icssg1HostPreQueueMem_0)
+            *(*gEnetSoc_icssg1HostPreQueueMem_1)
+        #endif
+    #endif
+#endif
+        }
+    } > MSRAM
+
+
+    /* This is rest of code. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .text:   {} palign(8)   /* This is where code resides */
+        .rodata: {} palign(8)   /* This is where const's go */
+    } > DDR
+
+    /* This is rest of initialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .data:   {} palign(8)   /* This is where initialized globals and static go */
+    } > DDR
+
+
+    /* This is rest of uninitialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .sysmem: {} palign(8)   /* This is where the malloc heap goes */
+        .stack:  {} palign(8)   /* This is where the main() stack goes */
+    } > DDR
+
+    .enet_dma_mem {
+        *(*ENET_DMA_DESC_MEMPOOL)
+        *(*ENET_DMA_RING_MEMPOOL)
+#if (ENET_SYSCFG_PKT_POOL_ENABLE == 1)
+        *(*ENET_DMA_PKT_MEMPOOL)
+#endif
+    } (NOLOAD) > MSRAM
+
+    GROUP {
+        .bss:    {} palign(8)   /* This is where uninitialized globals go */
+        RUN_START(__BSS_START)
+        RUN_END(__BSS_END)
+    } > DDR
+
+    /* This is where the stacks for different R5F modes go */
+    GROUP {
+        .irqstack: {. = . + __IRQ_STACK_SIZE;} align(8)
+        RUN_START(__IRQ_STACK_START)
+        RUN_END(__IRQ_STACK_END)
+        .fiqstack: {. = . + __FIQ_STACK_SIZE;} align(8)
+        RUN_START(__FIQ_STACK_START)
+        RUN_END(__FIQ_STACK_END)
+        .svcstack: {. = . + __SVC_STACK_SIZE;} align(8)
+        RUN_START(__SVC_STACK_START)
+        RUN_END(__SVC_STACK_END)
+        .abortstack: {. = . + __ABORT_STACK_SIZE;} align(8)
+        RUN_START(__ABORT_STACK_START)
+        RUN_END(__ABORT_STACK_END)
+        .undefinedstack: {. = . + __UNDEFINED_STACK_SIZE;} align(8)
+        RUN_START(__UNDEFINED_STACK_START)
+        RUN_END(__UNDEFINED_STACK_END)
+    } > DDR
+
+    /* General purpose user shared memory, used in some examples */
+    .bss.user_shared_mem (NOLOAD) : {} > USER_SHM_MEM
+    /* this is used when Debug log's to shared memory are enabled, else this is not used */
+    .bss.log_shared_mem  (NOLOAD) : {} > LOG_SHM_MEM
+    /* this is used only when IPC RPMessage is enabled, else this is not used */
+    .bss.ipc_vring_mem   (NOLOAD) : {} > RTOS_NORTOS_IPC_SHM_MEM
+
+    .bss:ENET_DMA_OBJ_MEM      (NOLOAD) {} ALIGN (128) > DDR
+    .bss:ENET_DMA_PKT_INFO_MEMPOOL (NOLOAD) {} ALIGN (128) > DDR
+
+    .bss:ENET_ICSSG_OCMC_MEM (NOLOAD) {} ALIGN (128) > MSRAM
+}
+
+/*
+NOTE: Below memory is reserved for DMSC usage
+ - During Boot till security handoff is complete
+   0x701E0000 - 0x701FFFFF (128KB)
+ - After "Security Handoff" is complete (i.e at run time)
+   0x701FC000 - 0x701FFFFF (16KB)
+
+ Security handoff is complete when this message is sent to the DMSC,
+   TISCI_MSG_SEC_HANDOVER
+
+ This should be sent once all cores are loaded and all application
+ specific firewall calls are setup.
+*/
+
+MEMORY
+{
+    R5F_VECS  : ORIGIN = 0x00000000 , LENGTH = 0x00000040
+    R5F_TCMA  : ORIGIN = 0x00000040 , LENGTH = 0x00007FC0
+    R5F_TCMB0 : ORIGIN = 0x41010000 , LENGTH = 0x00008000
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with other R5F's
+     */
+    MSRAM     : ORIGIN = 0x70083000 , LENGTH = 0xB9700
+
+    /* This section can be used to put XIP section of the application in flash, make sure this does not overlap with
+     * other CPUs. Also make sure to add a MPU entry for this section and mark it as cached and code executable
+     */
+    FLASH     : ORIGIN = 0x60200000 , LENGTH = 0x100000
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with other R5F's
+     */
+    DDR       : ORIGIN = 0x80120000 , LENGTH = 0x100000
+
+    /* shared memory segments */
+    /* On R5F,
+     * - make sure there is a MPU entry which maps below regions as non-cache
+     */
+    USER_SHM_MEM            : ORIGIN = 0x701D0000, LENGTH = 0x00004000
+    LOG_SHM_MEM             : ORIGIN = 0x701D4000, LENGTH = 0x00004000
+    RTOS_NORTOS_IPC_SHM_MEM : ORIGIN = 0x701D8000, LENGTH = 0x00008000
+
+}

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -1,0 +1,422 @@
+
+export MCU_PLUS_SDK_PATH?=$(abspath ../../../../../../../../../..)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=enet_netxduo_icssg_iperf.$(PROFILE).out
+COREOUTNAME:=enet_netxduo_icssg_iperf.$(PROFILE).optishare.out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=enet_netxduo_icssg_iperf.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=enet_netxduo_icssg_iperf.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=enet_netxduo_icssg_iperf.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=enet_netxduo_icssg_iperf.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=enet_netxduo_icssg_iperf.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=enet_netxduo_icssg_iperf.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=enet_netxduo_icssg_iperf.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=enet_netxduo_icssg_iperf.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	netxduo_icssg.c \
+	enet_icssg_link.c \
+	main.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+	ti_enet_config.c \
+	ti_enet_open_close.c \
+	ti_enet_soc.c \
+	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/board/ethphy/enet/rtos_drivers/include \
+	-I${MCU_PLUS_SDK_PATH}/source/board/ethphy/port \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/threadx_src/common/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/ports/cortex_r5/gnu/inc/ \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/utils/include \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/utils/V3 \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/phy \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/core \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/soc/k3/am64x_am243x \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include/mdio/V4 \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ftp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/http \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mdns \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mqtt \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/nat \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3 \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/snmp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/sntp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/telnet \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/tftp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/web \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/websocket \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM243X \
+	-DNX_INCLUDE_USER_DEFINE_FILE \
+	-DENET_ENABLE_PER_ICSSG=1 \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_release := \
+	-Os \
+	-Oz \
+	-flto \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+LNK_FILES_common = \
+	generated/../linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-igenerated \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/networking/netxduo/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/fs/filex/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/threadx/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/networking/enet/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lthreadx.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lnetxduo.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lfilex.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lenet-icssg.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+	-Wl,--gen_xml_func_hash \
+	-Wl,--zero_init=on \
+	-Wl,--use_memset=fast \
+	-Wl,--use_memcpy=fast \
+
+LNKOPTFLAGS_release = \
+		   -mcpu=cortex-r5 \
+		   -mfloat-abi=hard \
+		   -mfpu=vfpv3-d16 \
+		   -mthumb \
+		   -Oz \
+		   -flto \
+
+LIBS_NAME = \
+	threadx.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	netxduo.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	filex.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	enet-icssg.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	generated \
+	${MCU_PLUS_SDK_PATH}/source/networking/netxduo/lib \
+	${MCU_PLUS_SDK_PATH}/source/fs/filex/lib \
+	${MCU_PLUS_SDK_PATH}/source/kernel/threadx/lib \
+	${MCU_PLUS_SDK_PATH}/source/networking/enet/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am243x:r5fss0-0:threadx:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am243x:r5fss0-0:threadx:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
+SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
+SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am243x:r5fss0-0:threadx:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES) -Wl,--xml_link_info=$(basename $@).lnkxml
+	@echo  Linking: am243x:r5fss0-0:threadx:ti-arm-clang $@ Done !!!
+	@echo  .
+
+coreout: $(COREOUTNAME)
+$(COREOUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Relinking Linking: am243x:r5fss0-0:threadx:ti-arm-clang $@ with OptiShare SSO..
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES) -Wl,--xml_link_info=$(basename $@).lnkxml -Wl,--import_sso=$(SSO_PATH)
+	@echo  Relinking with optishare: am243x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am243x:r5fss0-0:threadx:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am243x:r5fss0-0:threadx:ti-arm-clang enet_netxduo_icssg_iperf ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.lnkxml
+	$(RM) \*.ossr
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.lnkxml
+	$(RM) *.ossr
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --context r5fss0-0 --part ALV --package ALV --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --device AM243x_ALV_beta --context r5fss0-0 --part ALV --package ALV --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for enet_netxduo_icssg_iperf.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o enet_netxduo_icssg_iperf.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=enet_netxduo_icssg_iperf.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=enet_netxduo_icssg_iperf.$(PROFILE).profdata > coverage/enet_netxduo_icssg_iperf.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/enet_netxduo_icssg_iperf.$(PROFILE).profdata.json --output-json=coverage/enet_netxduo_icssg_iperf.$(PROFILE).analysis.json --output=../enet_netxduo_icssg_iperf.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,109 @@
+
+# Below variables need to be defined outside this file or via command line
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile_projectspec
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,17 @@
+
+export MCU_PLUS_SDK_PATH?=$(abspath ../../../../../../../../../..)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=enet_netxduo_icssg_iperf_am243x-evm_r5fss0-0_threadx_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(MCU_PLUS_SDK_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-evm/r5fss0-0_threadx/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/example.syscfg
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/example.syscfg
@@ -1,0 +1,181 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM243x_ALX_beta" --part "ALX" --package "ALX" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM2434" --package "FCCSP (ALX)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.21.2+3837"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const eeprom     = scripting.addModule("/board/eeprom/eeprom", {}, false);
+const eeprom1    = eeprom.addInstance();
+const i2c        = scripting.addModule("/drivers/i2c/i2c", {}, false);
+const i2c1       = i2c.addInstance();
+const pruicss    = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1   = pruicss.addInstance();
+const debug_log  = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg    = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7  = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71 = mpu_armv7.addInstance();
+const mpu_armv72 = mpu_armv7.addInstance();
+const mpu_armv73 = mpu_armv7.addInstance();
+const mpu_armv74 = mpu_armv7.addInstance();
+const mpu_armv75 = mpu_armv7.addInstance();
+const mpu_armv76 = mpu_armv7.addInstance();
+const enet_icss  = scripting.addModule("/networking/enet_icss/enet_icss", {}, false);
+const enet_icss1 = enet_icss.addInstance();
+const enet_icss2 = enet_icss.addInstance();
+const netxduo    = scripting.addModule("/networking/netxduo/netxduo", {}, false);
+const netxduo1   = netxduo.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+eeprom1.$name = "CONFIG_EEPROM0";
+
+i2c1.$name               = "CONFIG_I2C0";
+eeprom1.peripheralDriver = i2c1;
+i2c1.I2C.$assign         = "I2C0";
+i2c1.I2C_child.$name     = "drivers_i2c_v0_i2c_v0_template1";
+
+debug_log.enableUartLog        = true;
+debug_log.enableCssLog         = false;
+debug_log.uartLog.$name        = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign = "USART0";
+
+const uart_v0_template  = scripting.addModule("/drivers/uart/v0/uart_v0_template", {}, false);
+const uart_v0_template1 = uart_v0_template.addInstance({}, false);
+uart_v0_template1.$name = "drivers_uart_v0_uart_v0_template0";
+debug_log.uartLog.child = uart_v0_template1;
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 23;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION5";
+mpu_armv75.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv75.baseAddr          = 0xA5000000;
+mpu_armv75.size              = 23;
+mpu_armv75.attributes        = "NonCached";
+
+mpu_armv76.$name    = "CONFIG_MPU_REGION6";
+mpu_armv76.size     = 27;
+mpu_armv76.baseAddr = 0x60000000;
+
+enet_icss1.$name                         = "CONFIG_ENET_ICSS0";
+enet_icss1.phyToMacInterfaceMode         = "RGMII";
+enet_icss1.mdioDisableStateMachineOnInit = true;
+enet_icss1.mdioMode                      = "MDIO_MODE_MANUAL";
+enet_icss1.mode                          = "DUAL MAC";
+enet_icss1.PktInfoOnlyEnable             = true;
+enet_icss1.PktPoolEnable                 = false;
+enet_icss1.PktInfoOnlyCount              = 48;
+enet_icss1.txDmaChannel[0].$name         = "ENET_DMA_TX_CH0";
+enet_icss1.PRU_ICSSG1_RGMII1.$assign     = "PRU_ICSSG1_RGMII1";
+enet_icss1.rxDmaChannel[0].$name         = "ENET_DMA_RX_CH0";
+
+const ethphy_cpsw_icssg  = scripting.addModule("/board/ethphy_cpsw_icssg/ethphy_cpsw_icssg", {}, false);
+const ethphy_cpsw_icssg1 = ethphy_cpsw_icssg.addInstance({}, false);
+ethphy_cpsw_icssg1.$name = "CONFIG_ENET_ETHPHY0";
+enet_icss1.ethphy2       = ethphy_cpsw_icssg1;
+
+enet_icss2.$name                 = "CONFIG_ENET_ICSS1";
+enet_icss2.mode                  = "DUAL MAC";
+enet_icss2.dualMacPortSelected   = "ENET_MAC_PORT_2";
+enet_icss2.mdioMdcEnable         = false;
+enet_icss2.phyToMacInterfaceMode = "RGMII";
+enet_icss2.PktPoolEnable         = false;
+enet_icss2.PktInfoOnlyEnable     = true;
+enet_icss2.PktInfoOnlyCount      = 48;
+enet_icss2.txDmaChannel[0].$name = "ENET_DMA_TX_CH1";
+enet_icss2.rxDmaChannel[0].$name = "ENET_DMA_RX_CH1";
+
+const ethphy_cpsw_icssg2 = ethphy_cpsw_icssg.addInstance({}, false);
+ethphy_cpsw_icssg2.$name = "CONFIG_ENET_ETHPHY1";
+enet_icss2.ethphy3       = ethphy_cpsw_icssg2;
+
+enet_icss1.icss                          = pruicss1;
+pruicss1.$name                           = "CONFIG_PRU_ICSS1";
+enet_icss2.icss                          = pruicss1;
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+pruicss1.intcMapping.create(2);
+pruicss1.intcMapping[0].$name            = "CONFIG_ICSS1_INTC_MAPPING0";
+pruicss1.intcMapping[0].event            = "41";
+pruicss1.intcMapping[0].channel          = "7";
+pruicss1.intcMapping[0].host             = "8";
+pruicss1.intcMapping[1].$name            = "CONFIG_ICSS1_INTC_MAPPING1";
+pruicss1.intcMapping[1].event            = "53";
+pruicss1.intcMapping[1].channel          = "7";
+pruicss1.intcMapping[1].host             = "8";
+
+const udma         = scripting.addModule("/drivers/udma/udma", {}, false);
+const udma1        = udma.addInstance({}, false);
+enet_icss1.udmaDrv = udma1;
+enet_icss2.udmaDrv = udma1;
+
+netxduo1.$name                                   = "CONFIG_NETXDUO0";
+netxduo1.netxduoIfInstance.create(2);
+netxduo1.netxduoIfInstance[0].$name              = "CONFIG_NETX_IF0";
+netxduo1.netxduoIfInstance[0].isDefault          = true;
+netxduo1.netxduoIfInstance[0].enet_instance_name = "CONFIG_ENET_ICSS0";
+netxduo1.netxduoIfInstance[1].$name              = "CONFIG_NETX_IF1";
+netxduo1.netxduoIfInstance[1].enet_instance_name = "CONFIG_ENET_ICSS1";
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+i2c1.I2C.SCL.$suggestSolution                            = "I2C0_SCL";
+i2c1.I2C.SDA.$suggestSolution                            = "I2C0_SDA";
+debug_log.uartLog.UART.RXD.$suggestSolution              = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$suggestSolution              = "UART0_TXD";
+enet_icss1.PRU_ICSSG1_MDIO.$suggestSolution              = "PRU_ICSSG1_MDIO0";
+enet_icss1.PRU_ICSSG1_MDIO.MDC.$suggestSolution          = "PRG1_MDIO0_MDC";
+enet_icss1.PRU_ICSSG1_MDIO.MDIO.$suggestSolution         = "PRG1_MDIO0_MDIO";
+enet_icss1.PRU_ICSSG1_IEP.$suggestSolution               = "PRU_ICSSG1_IEP0";
+enet_icss1.PRU_ICSSG1_IEP.EDC_LATCH_IN0.$suggestSolution = "PRG1_PRU0_GPO18";
+enet_icss1.PRU_ICSSG1_IEP.EDC_SYNC_OUT0.$suggestSolution = "PRG1_PRU0_GPO19";
+enet_icss1.PRU_ICSSG1_RGMII1.RD0.$suggestSolution        = "PRG1_PRU0_GPO0";
+enet_icss1.PRU_ICSSG1_RGMII1.RD1.$suggestSolution        = "PRG1_PRU0_GPO1";
+enet_icss1.PRU_ICSSG1_RGMII1.RD2.$suggestSolution        = "PRG1_PRU0_GPO2";
+enet_icss1.PRU_ICSSG1_RGMII1.RD3.$suggestSolution        = "PRG1_PRU0_GPO3";
+enet_icss1.PRU_ICSSG1_RGMII1.RXC.$suggestSolution        = "PRG1_PRU0_GPO6";
+enet_icss1.PRU_ICSSG1_RGMII1.RX_CTL.$suggestSolution     = "PRG1_PRU0_GPO4";
+enet_icss1.PRU_ICSSG1_RGMII1.TD0.$suggestSolution        = "PRG1_PRU0_GPO11";
+enet_icss1.PRU_ICSSG1_RGMII1.TD1.$suggestSolution        = "PRG1_PRU0_GPO12";
+enet_icss1.PRU_ICSSG1_RGMII1.TD2.$suggestSolution        = "PRG1_PRU0_GPO13";
+enet_icss1.PRU_ICSSG1_RGMII1.TD3.$suggestSolution        = "PRG1_PRU0_GPO14";
+enet_icss1.PRU_ICSSG1_RGMII1.TXC.$suggestSolution        = "PRG1_PRU0_GPO16";
+enet_icss1.PRU_ICSSG1_RGMII1.TX_CTL.$suggestSolution     = "PRG1_PRU0_GPO15";
+enet_icss2.PRU_ICSSG1_RGMII2.$suggestSolution            = "PRU_ICSSG1_RGMII2";
+enet_icss2.PRU_ICSSG1_RGMII2.RD0.$suggestSolution        = "PRG1_PRU1_GPO0";
+enet_icss2.PRU_ICSSG1_RGMII2.RD1.$suggestSolution        = "PRG1_PRU1_GPO1";
+enet_icss2.PRU_ICSSG1_RGMII2.RD2.$suggestSolution        = "PRG1_PRU1_GPO2";
+enet_icss2.PRU_ICSSG1_RGMII2.RD3.$suggestSolution        = "PRG1_PRU1_GPO3";
+enet_icss2.PRU_ICSSG1_RGMII2.RXC.$suggestSolution        = "PRG1_PRU1_GPO6";
+enet_icss2.PRU_ICSSG1_RGMII2.RX_CTL.$suggestSolution     = "PRG1_PRU1_GPO4";
+enet_icss2.PRU_ICSSG1_RGMII2.TD0.$suggestSolution        = "PRG1_PRU1_GPO11";
+enet_icss2.PRU_ICSSG1_RGMII2.TD1.$suggestSolution        = "PRG1_PRU1_GPO12";
+enet_icss2.PRU_ICSSG1_RGMII2.TD2.$suggestSolution        = "PRG1_PRU1_GPO13";
+enet_icss2.PRU_ICSSG1_RGMII2.TD3.$suggestSolution        = "PRG1_PRU1_GPO14";
+enet_icss2.PRU_ICSSG1_RGMII2.TXC.$suggestSolution        = "PRG1_PRU1_GPO16";
+enet_icss2.PRU_ICSSG1_RGMII2.TX_CTL.$suggestSolution     = "PRG1_PRU1_GPO15";

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/main.c
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2018-2024 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include <tx_api.h>
+
+
+#define MAIN_TASK_PRI  (4)
+
+#define MAIN_TASK_STACK_SIZE (8192U)
+
+uint8_t main_thread_stack[MAIN_TASK_STACK_SIZE] __attribute__((aligned(32)));
+
+TX_THREAD main_thread;
+
+void netxduo_icssg_main(void *args);
+
+void threadx_main(ULONG arg)
+{
+    netxduo_icssg_main(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* Enter the ThreadX kernel.  */
+    tx_kernel_enter();
+}
+
+void tx_application_define(void *first_unused_memory)
+{
+    UINT status;
+
+    status = tx_thread_create(&main_thread,           /* Pointer to the main thread object. */ 
+                              "main_thread",          /* Name of the task for debugging purposes. */
+                              threadx_main,           /* Entry function for the main thread. */
+                              0,                      /* Arguments passed to the entry function. */  
+                              main_thread_stack,      /* Main thread stack. */
+                              MAIN_TASK_STACK_SIZE,   /* Main thread stack size in bytes. */
+                              MAIN_TASK_PRI,          /* Main task priority. */
+                              MAIN_TASK_PRI,          /* Highest priority level of disabled preemption. */
+                              TX_NO_TIME_SLICE,       /* No time slice. */
+                              TX_AUTO_START);         /* Start immediately. */
+
+    DebugP_assertNoLog(status == TX_SUCCESS);
+}
+
+

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/ti-arm-clang/example.projectspec
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/ti-arm-clang/example.projectspec
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM2434_ALX"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Enet Netxduo Icssg Iperf"
+        name = "enet_netxduo_icssg_iperf_am243x-lp_r5fss0-0_threadx_ti-arm-clang"
+        products="sysconfig;com.ti.MCU_PLUS_SDK_AMXXX"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.1"
+        device="Cortex R.AM2434_ALX"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/board/ethphy/enet/rtos_drivers/include
+            -I${MCU_PLUS_SDK_PATH}/source/board/ethphy/port
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/threadx_src/common/inc
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/inc
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/ports/cortex_r5/gnu/inc/
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/utils/include
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/utils/V3
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/phy
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/core
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/soc/k3/am64x_am243x
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include
+            -I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include/mdio/V4
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ftp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/http
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mdns
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mqtt
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/nat
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/snmp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/sntp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/telnet
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/tftp
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/web
+            -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/websocket
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM243X
+            -DNX_INCLUDE_USER_DEFINE_FILE
+            -DENET_ENABLE_PER_ICSSG=1
+        "
+        linkerBuildOptions="
+            -igenerated
+            -i${MCU_PLUS_SDK_PATH}/source/networking/netxduo/lib
+            -i${MCU_PLUS_SDK_PATH}/source/fs/filex/lib
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/threadx/lib
+            -i${MCU_PLUS_SDK_PATH}/source/networking/enet/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${CG_TOOL_ROOT}/lib
+            -i${PROJECT_BUILD_DIR}/syscfg
+            -m=enet_netxduo_icssg_iperf.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+            --gen_xml_func_hash
+            --zero_init=on
+            --use_memset=fast
+            --use_memcpy=fast
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am243x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part ALX --package ALX
+        "
+
+        description="A Enet Netxduo Icssg Iperf THREADX project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lthreadx.am243x.r5f.ti-arm-clang.debug.lib
+                -lnetxduo.am243x.r5f.ti-arm-clang.debug.lib
+                -lfilex.am243x.r5f.ti-arm-clang.debug.lib
+                -lenet-icssg.am243x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.debug.lib
+                -lboard.am243x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+                -Oz
+                -flto
+            "
+            linkerBuildOptions="
+                -lthreadx.am243x.r5f.ti-arm-clang.release.lib
+                -lnetxduo.am243x.r5f.ti-arm-clang.release.lib
+                -lfilex.am243x.r5f.ti-arm-clang.release.lib
+                -lenet-icssg.am243x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.release.lib
+                -lboard.am243x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AMXXX_INSTALL_DIR}" scope="project" />
+        <file path="../../../netxduo_icssg.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../../../enet_icssg_link.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="linker.cmd" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="link">
+        </file>
+        <file path="${MCU_PLUS_SDK_PATH}/docs/api_guide_am243x/EXAMPLES_ECLIPSE_THREADX_NETXDUO_ICSSG_IPERF.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/ti-arm-clang/linker.cmd
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/ti-arm-clang/linker.cmd
@@ -1,0 +1,221 @@
+#include "ti_enet_config.h"
+
+/* This is the stack that is used by code running within main()
+ * In case of NORTOS,
+ * - This means all the code outside of ISR uses this stack
+ * In case of FreeRTOS
+ * - This means all the code until vTaskStartScheduler() is called in main()
+ *   uses this stack.
+ * - After vTaskStartScheduler() each task created in FreeRTOS has its own stack
+ */
+--stack_size=8192
+/* This is the heap size for malloc() API in NORTOS and FreeRTOS
+ * This is also the heap used by pvPortMalloc in FreeRTOS
+ */
+--heap_size=34000
+-e_vectors  /* This is the entry of the application, _vector MUST be plabed starting address 0x0 */
+
+/* This is the size of stack when R5 is in IRQ mode
+ * In NORTOS,
+ * - Here interrupt nesting is disabled as of now
+ * - This is the stack used by ISRs registered as type IRQ
+ * In FreeRTOS,
+ * - Here interrupt nesting is enabled
+ * - This is stack that is used initally when a IRQ is received
+ * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
+ * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
+ */
+__IRQ_STACK_SIZE = 4096;
+/* This is the size of stack when R5 is in IRQ mode
+ * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
+ */
+__FIQ_STACK_SIZE = 4096;
+__SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
+__ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
+__UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */
+
+SECTIONS
+{
+    /* This has the R5F entry point and vector table, this MUST be at 0x0 */
+    .vectors:{} palign(8) > R5F_VECS
+
+    /* This has the R5F boot code until MPU is enabled,  this MUST be at a address < 0x80000000
+     * i.e this cannot be placed in DDR
+     */
+    GROUP {
+        .text.hwi: palign(8)
+        .text.cache: palign(8)
+        .text.mpu: palign(8)
+        .text.boot: palign(8)
+        .text:abort: palign(8) /* this helps in loading symbols when using XIP mode */
+    } > MSRAM
+
+    UNION
+    {
+        .icssfw: palign(128)
+
+        .icss_mem: type = NOLOAD , palign(128) {
+#if (ENET_SYSCFG_ICSSG0_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 1)
+        #if(ENET_SYSCFG_DUALMAC_PORT1_ENABLED == 1)
+            *(*gEnetSoc_icssg0HostPoolMem_0)
+            *(*gEnetSoc_icssg0HostQueueMem_0)
+            *(*gEnetSoc_icssg0ScratchMem_0)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                *(*gEnetSoc_icssg0HostPreQueueMem_0)
+            #endif
+        #else
+            *(*gEnetSoc_icssg0HostPoolMem_1)
+            *(*gEnetSoc_icssg0HostQueueMem_1)
+            *(*gEnetSoc_icssg0ScratchMem_1)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                    *(*gEnetSoc_icssg0HostPreQueueMem_1)
+            #endif
+        #endif
+    #endif
+#endif
+#if (ENET_SYSCFG_ICSSG1_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 1)
+        #if(ENET_SYSCFG_DUALMAC_PORT1_ENABLED == 1)
+                *(*gEnetSoc_icssg1HostPoolMem_0)
+                *(*gEnetSoc_icssg1HostQueueMem_0)
+                *(*gEnetSoc_icssg1ScratchMem_0)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                *(*gEnetSoc_icssg1HostPreQueueMem_0)
+            #endif
+        #else
+                *(*gEnetSoc_icssg1HostPoolMem_1)
+                *(*gEnetSoc_icssg1HostQueueMem_1)
+                *(*gEnetSoc_icssg1ScratchMem_1)
+            #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+                *(*gEnetSoc_icssg1HostPreQueueMem_1)
+            #endif
+        #endif
+    #endif
+#endif
+#if (ENET_SYSCFG_ICSSG0_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 0)
+        *(*gEnetSoc_icssg0PortPoolMem_0)
+        *(*gEnetSoc_icssg0PortPoolMem_1)
+        *(*gEnetSoc_icssg0HostPoolMem_0)
+        *(*gEnetSoc_icssg0HostPoolMem_1)
+        *(*gEnetSoc_icssg0HostQueueMem_0)
+        *(*gEnetSoc_icssg0HostQueueMem_1)
+        *(*gEnetSoc_icssg0ScratchMem_0)
+        *(*gEnetSoc_icssg0ScratchMem_1)
+        #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+            *(*gEnetSoc_icssg0HostPreQueueMem_0)
+            *(*gEnetSoc_icssg0HostPreQueueMem_1)
+        #endif
+    #endif
+#endif
+#if (ENET_SYSCFG_ICSSG1_ENABLED == 1)
+    #if(ENET_SYSCFG_DUAL_MAC == 0)
+        *(*gEnetSoc_icssg1PortPoolMem_0)
+        *(*gEnetSoc_icssg1PortPoolMem_1)
+        *(*gEnetSoc_icssg1HostPoolMem_0)
+        *(*gEnetSoc_icssg1HostPoolMem_1)
+        *(*gEnetSoc_icssg1HostQueueMem_0)
+        *(*gEnetSoc_icssg1HostQueueMem_1)
+        *(*gEnetSoc_icssg1ScratchMem_0)
+        *(*gEnetSoc_icssg1ScratchMem_1)
+        #if (ENET_SYSCFG_PREMPTION_ENABLE == 1)
+            *(*gEnetSoc_icssg1HostPreQueueMem_0)
+            *(*gEnetSoc_icssg1HostPreQueueMem_1)
+        #endif
+    #endif
+#endif
+        }
+    } > MSRAM
+
+
+    /* This is rest of code. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .text:   {} palign(8)   /* This is where code resides */
+        .rodata: {} palign(8)   /* This is where const's go */
+    } > MSRAM
+
+    /* This is rest of initialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .data:   {} palign(8)   /* This is where initialized globals and static go */
+    } > MSRAM
+
+    /* This is rest of uninitialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .sysmem: {} palign(8)   /* This is where the malloc heap goes */
+        .stack:  {} palign(8)   /* This is where the main() stack goes */
+    } > MSRAM\
+
+    GROUP {
+        .bss:    {} palign(8)   /* This is where uninitialized globals go */
+        RUN_START(__BSS_START)
+        RUN_END(__BSS_END)
+    } > MSRAM
+
+    /* This is where the stacks for different R5F modes go */
+    GROUP {
+        .irqstack: {. = . + __IRQ_STACK_SIZE;} align(8)
+        RUN_START(__IRQ_STACK_START)
+        RUN_END(__IRQ_STACK_END)
+        .fiqstack: {. = . + __FIQ_STACK_SIZE;} align(8)
+        RUN_START(__FIQ_STACK_START)
+        RUN_END(__FIQ_STACK_END)
+        .svcstack: {. = . + __SVC_STACK_SIZE;} align(8)
+        RUN_START(__SVC_STACK_START)
+        RUN_END(__SVC_STACK_END)
+        .abortstack: {. = . + __ABORT_STACK_SIZE;} align(8)
+        RUN_START(__ABORT_STACK_START)
+        RUN_END(__ABORT_STACK_END)
+        .undefinedstack: {. = . + __UNDEFINED_STACK_SIZE;} align(8)
+        RUN_START(__UNDEFINED_STACK_START)
+        RUN_END(__UNDEFINED_STACK_END)
+    } > MSRAM
+
+    .enet_dma_mem {
+        *(*ENET_DMA_DESC_MEMPOOL)
+        *(*ENET_DMA_RING_MEMPOOL)
+#if (ENET_SYSCFG_PKT_POOL_ENABLE == 1)
+        *(*ENET_DMA_PKT_MEMPOOL)
+#endif
+    } (NOLOAD) {} ALIGN (128) > MSRAM
+
+    .bss:ENET_DMA_OBJ_MEM (NOLOAD) {} ALIGN (128) > MSRAM
+    .bss:ENET_DMA_PKT_INFO_MEMPOOL (NOLOAD) {} ALIGN (128) > MSRAM
+    .bss:ENET_ICSSG_OCMC_MEM (NOLOAD) {} ALIGN (128) > MSRAM
+}
+
+/*
+NOTE: Below memory is reserved for DMSC usage
+ - During Boot till security handoff is complete
+   0x701E0000 - 0x701FFFFF (128KB)
+ - After "Security Handoff" is complete (i.e at run time)
+   0x701FC000 - 0x701FFFFF (16KB)
+
+ Security handoff is complete when this message is sent to the DMSC,
+   TISCI_MSG_SEC_HANDOVER
+
+ This should be sent once all cores are loaded and all application
+ specific firewall calls are setup.
+*/
+
+MEMORY
+{
+    R5F_VECS  : ORIGIN = 0x00000000 , LENGTH = 0x00000040
+    R5F_TCMA  : ORIGIN = 0x00000040 , LENGTH = 0x00007FC0
+    R5F_TCMB0 : ORIGIN = 0x41010000 , LENGTH = 0x00008000
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with other R5F's
+     */
+    MSRAM     : ORIGIN = 0x70080000 , LENGTH = 0x160000
+
+    /* This section can be used to put XIP section of the application in flash, make sure this does not overlap with
+     * other CPUs. Also make sure to add a MPU entry for this section and mark it as cached and code executable
+     */
+    FLASH     : ORIGIN = 0x60100000 , LENGTH = 0x100000
+
+    /* shared memory segments */
+    /* On R5F,
+     * - make sure there is a MPU entry which maps below regions as non-cache
+     */
+}

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -1,0 +1,422 @@
+
+export MCU_PLUS_SDK_PATH?=$(abspath ../../../../../../../../../..)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=enet_netxduo_icssg_iperf.$(PROFILE).out
+COREOUTNAME:=enet_netxduo_icssg_iperf.$(PROFILE).optishare.out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=enet_netxduo_icssg_iperf.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=enet_netxduo_icssg_iperf.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=enet_netxduo_icssg_iperf.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=enet_netxduo_icssg_iperf.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=enet_netxduo_icssg_iperf.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=enet_netxduo_icssg_iperf.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=enet_netxduo_icssg_iperf.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=enet_netxduo_icssg_iperf.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	netxduo_icssg.c \
+	enet_icssg_link.c \
+	main.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+	ti_enet_config.c \
+	ti_enet_open_close.c \
+	ti_enet_soc.c \
+	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/board/ethphy/enet/rtos_drivers/include \
+	-I${MCU_PLUS_SDK_PATH}/source/board/ethphy/port \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/threadx_src/common/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/inc \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/ports/cortex_r5/gnu/inc/ \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/utils/include \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/utils/V3 \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/phy \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/core/include/core \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/soc/k3/am64x_am243x \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include/mdio/V4 \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ftp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/http \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mdns \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/mqtt \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/nat \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3 \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/snmp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/sntp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/telnet \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/tftp \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/web \
+	-I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/websocket \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM243X \
+	-DNX_INCLUDE_USER_DEFINE_FILE \
+	-DENET_ENABLE_PER_ICSSG=1 \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_release := \
+	-Os \
+	-Oz \
+	-flto \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+LNK_FILES_common = \
+	generated/../linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-igenerated \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/networking/netxduo/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/fs/filex/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/threadx/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/networking/enet/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lthreadx.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lnetxduo.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lfilex.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lenet-icssg.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+	-Wl,--gen_xml_func_hash \
+	-Wl,--zero_init=on \
+	-Wl,--use_memset=fast \
+	-Wl,--use_memcpy=fast \
+
+LNKOPTFLAGS_release = \
+		   -mcpu=cortex-r5 \
+		   -mfloat-abi=hard \
+		   -mfpu=vfpv3-d16 \
+		   -mthumb \
+		   -Oz \
+		   -flto \
+
+LIBS_NAME = \
+	threadx.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	netxduo.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	filex.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	enet-icssg.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	generated \
+	${MCU_PLUS_SDK_PATH}/source/networking/netxduo/lib \
+	${MCU_PLUS_SDK_PATH}/source/fs/filex/lib \
+	${MCU_PLUS_SDK_PATH}/source/kernel/threadx/lib \
+	${MCU_PLUS_SDK_PATH}/source/networking/enet/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am243x:r5fss0-0:threadx:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am243x:r5fss0-0:threadx:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
+SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
+SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am243x:r5fss0-0:threadx:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES) -Wl,--xml_link_info=$(basename $@).lnkxml
+	@echo  Linking: am243x:r5fss0-0:threadx:ti-arm-clang $@ Done !!!
+	@echo  .
+
+coreout: $(COREOUTNAME)
+$(COREOUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Relinking Linking: am243x:r5fss0-0:threadx:ti-arm-clang $@ with OptiShare SSO..
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES) -Wl,--xml_link_info=$(basename $@).lnkxml -Wl,--import_sso=$(SSO_PATH)
+	@echo  Relinking with optishare: am243x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am243x:r5fss0-0:threadx:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am243x:r5fss0-0:threadx:ti-arm-clang enet_netxduo_icssg_iperf ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.lnkxml
+	$(RM) \*.ossr
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.lnkxml
+	$(RM) *.ossr
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --context r5fss0-0 --part ALX --package ALX --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --device AM243x_ALX_beta --context r5fss0-0 --part ALX --package ALX --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for enet_netxduo_icssg_iperf.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o enet_netxduo_icssg_iperf.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=enet_netxduo_icssg_iperf.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=enet_netxduo_icssg_iperf.$(PROFILE).profdata > coverage/enet_netxduo_icssg_iperf.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/enet_netxduo_icssg_iperf.$(PROFILE).profdata.json --output-json=coverage/enet_netxduo_icssg_iperf.$(PROFILE).analysis.json --output=../enet_netxduo_icssg_iperf.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,109 @@
+
+# Below variables need to be defined outside this file or via command line
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am243x:r5fss0-0:threadx:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile_projectspec
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,17 @@
+
+export MCU_PLUS_SDK_PATH?=$(abspath ../../../../../../../../../..)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=enet_netxduo_icssg_iperf_am243x-lp_r5fss0-0_threadx_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(MCU_PLUS_SDK_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/am243x-lp/r5fss0-0_threadx/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/examples/netxduo/enet_netxduo_icssg_iperf/enet_icssg_link.c
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/enet_icssg_link.c
@@ -1,0 +1,445 @@
+/*
+ * Copyright (c) 2001,2002 Florian Schulze.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the authors nor the names of the contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+
+/* C runtime includes */
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+
+#include "ti_board_config.h"
+/* SDK includes */
+#include "ti_drivers_open_close.h"
+#include "ti_drivers_config.h"
+#include "ti_board_open_close.h"
+#include "ti_enet_open_close.h"
+#include "ti_enet_config.h"
+#include <kernel/dpl/TaskP.h>
+#include <kernel/dpl/ClockP.h>
+#include <kernel/dpl/QueueP.h>
+
+#include <enet_apputils.h>
+
+#if (ENET_SYSCFG_ENABLE_EXTPHY == 1)
+#include "enetextphy.h"
+#include "enetextphy_phymdio_dflt.h"
+#include "test_enet_extphy.h"
+#endif
+
+#if (ENET_SYSCFG_ENABLE_EXTPHY == 0U)
+static void EnetApp_mdioLinkStatusChange(Icssg_MdioLinkStateChangeInfo *info,
+                                         void *appArg);
+#else
+EnetExtPhy_Handle EnetApp_getExtPhyHandle(Enet_MacPort macPort);
+#endif
+
+static void EnetApp_handleLinkChangeEvent(Enet_Handle hEnet,
+                                          Icssg_MdioLinkStateChangeInfo*
+                                          pLinkChangeInfo);
+
+#define MII_LINK0_EVENT      41
+#define MII_LINK1_EVENT      53
+
+#if (ENET_SYSCFG_ENABLE_EXTPHY == 1U)
+
+#define ENETAPP_MDIOLINKINT_HANDLER_TASK_PRIORITY        (7U)
+#define ENETAPP_MDIOLINKINT_HANDLER_TASK_STACK     (3 * 1024)
+
+typedef struct EnetAppPhyLinkEventInfoMsg_s
+{
+    QueueP_Elem elem;
+    Icssg_MdioLinkStateChangeInfo linkStateChangeInfo;
+    void *mdioLinkStateChangeCbArg;
+} EnetAppPhyLinkEventInfoMsg;
+
+typedef struct EnetAppPhyPollState_s
+{
+    uint32_t aliveStatusPhyAddMask;
+    uint32_t linkStatusPhyAddMask;
+    uint32_t pollEnablePhyAddMask;
+} EnetAppPhyPollState_s;
+
+
+typedef struct EnetAppPhyLinkEventCtx_s
+{
+    Enet_Type port2EnetType[ENET_SYSCFG_MAX_MAC_PORTS];
+    uint32_t port2InstId[ENET_SYSCFG_MAX_MAC_PORTS];
+    uint32_t mdioLinkChangeIsrCount;
+    QueueP_Object freeMsgQ;
+    QueueP_Object processMsgQ;
+    QueueP_Handle hFreeMsgQ;
+    QueueP_Handle hProcessMsgQ;
+    EnetAppPhyLinkEventInfoMsg infoMsg[QueueP_OBJECT_SIZE_MAX];
+    /*! MDIO Link state change callback function pointer */
+    Icssg_MdioLinkStateChangeCb appMdioLinkStateChangeCb;
+    /*! Application data to be passed to the MDIO link state change callback */
+    void *appMdioLinkStateChangeCbArg;
+    bool mdioLinkIntTaskShutDownFlag;
+    TaskP_Object taskMdioLinkIntHandlerObj;
+    ClockP_Object phyRegPollTimerObj;
+    SemaphoreP_Object linkIntSem;
+    uint8_t appMdioLinkIntHandlerTaskStack[ENETAPP_MDIOLINKINT_HANDLER_TASK_STACK] __attribute__ ((aligned(32)));
+    EnetAppPhyPollState_s phyPollState;
+    bool isInitialized;
+} EnetAppPhyLinkEventCtx;
+
+EnetAppPhyLinkEventCtx gMdioLinkEventCtx = {.isInitialized = false};
+
+
+void EnetApp_initPhyLinkHandlerCtx(EnetAppPhyLinkEventCtx * ctx, Enet_Type port2EnetType[ENET_SYSCFG_MAX_MAC_PORTS], uint32_t port2InstId[ENET_SYSCFG_MAX_MAC_PORTS])
+{
+    uint32_t i;
+    int32_t status;
+
+    for (uint32_t idx = 0; idx < ENET_SYSCFG_MAX_MAC_PORTS; idx++)
+    {
+        ctx->port2EnetType[idx] = port2EnetType[idx];
+        ctx->port2InstId[idx]   = port2InstId[idx];
+    }
+    ctx->mdioLinkChangeIsrCount = 0;
+    ctx->mdioLinkIntTaskShutDownFlag = false;
+    status = SemaphoreP_constructCounting(&ctx->linkIntSem, 0, ENET_ARRAYSIZE(ctx->infoMsg));
+    EnetAppUtils_assert(status == SystemP_SUCCESS);
+
+    ctx->hFreeMsgQ = QueueP_create(&(ctx->freeMsgQ));
+    EnetAppUtils_assert(ctx->hFreeMsgQ != NULL);
+    ctx->hProcessMsgQ =  QueueP_create(&(ctx->processMsgQ));
+    EnetAppUtils_assert(ctx->hProcessMsgQ != NULL);
+
+    ENET_UTILS_COMPILETIME_ASSERT(offsetof(EnetAppPhyLinkEventInfoMsg, elem) == 0);
+    for (i = 0; i < ENET_ARRAYSIZE(ctx->infoMsg); i++)
+    {
+        status = QueueP_put(ctx->hFreeMsgQ, &ctx->infoMsg[i].elem);
+        EnetAppUtils_assert(status == SystemP_SUCCESS);
+    }
+}
+
+static void EnetApp_mdioLinkIntHandler(void * appHandle)
+{
+    EnetAppPhyLinkEventCtx *linkIntCtx  = (EnetAppPhyLinkEventCtx *)appHandle;
+    SemaphoreP_Object *linkIntSem       = &linkIntCtx->linkIntSem;
+    while (linkIntCtx->mdioLinkIntTaskShutDownFlag != true)
+    {
+        SemaphoreP_pend(linkIntSem, SystemP_WAIT_FOREVER);
+        {
+            uint32_t status;
+            Icssg_MdioLinkStateChangeInfo *pLinkChangeInfo;
+            QueueP_Elem *qelem;
+            EnetAppPhyLinkEventInfoMsg *infoMsg;
+
+            qelem = QueueP_get(linkIntCtx->hProcessMsgQ);
+            EnetAppUtils_assert(qelem != NULL);
+            infoMsg = container_of(qelem, EnetAppPhyLinkEventInfoMsg, elem);
+            pLinkChangeInfo = &infoMsg->linkStateChangeInfo;
+
+            if (pLinkChangeInfo->linkChanged)
+            {
+
+                for (uint32_t macPort = 0; macPort < ENET_SYSCFG_MAX_MAC_PORTS; macPort++)
+                {
+                    const EnetExtPhy_Handle hPhy = EnetApp_getExtPhyHandle(macPort);
+                    if (hPhy == NULL)
+                    {
+                        continue;
+                    }
+                    const uint32_t phyAddress = hPhy->phyCfg.phyAddr;
+                    if (phyAddress == infoMsg->linkStateChangeInfo.phyAddr)
+                    {
+                        /* For here for the PHY whose link has changed */
+                        Enet_Handle hEnet = Enet_getHandle(linkIntCtx->port2EnetType[macPort], linkIntCtx->port2InstId[macPort]);
+                        EnetApp_handleLinkChangeEvent(hEnet, pLinkChangeInfo);
+                        break;
+                    }
+
+                }
+            }
+            status = QueueP_put(linkIntCtx->hFreeMsgQ, &infoMsg->elem);
+            EnetAppUtils_assert(status == SystemP_SUCCESS);
+       }
+    }
+}
+
+static void EnetApp_handleLinkChangeEvent(Enet_Handle hEnet, Icssg_MdioLinkStateChangeInfo* pLinkChangeInfo)
+{
+    uint32_t status = ENET_SOK;
+    Enet_MacPort macPort;
+    Enet_IoctlPrms prms;
+    const uint32_t selfCoreId = EnetSoc_getCoreId();
+
+    if (pLinkChangeInfo->isLinked)
+    {
+        Enet_Type enetType;
+        uint32_t instId;
+
+        Enet_ExtPhyLinkUpEventInfo linkupEventInfo;
+
+
+        status = Enet_getHandleInfo(hEnet, &enetType, &instId);
+        EnetAppUtils_assert(status == ENET_SOK);
+        status = EnetApp_getExtPhyLinkCfgInfo(enetType,
+                                     instId,
+                                     &macPort,
+                                     pLinkChangeInfo->phyAddr,
+                                     &linkupEventInfo.phyLinkCfg);
+        if (ENETEXTPHY_SOK == status)
+        {
+            linkupEventInfo.macPort = macPort;
+            ENET_IOCTL_SET_IN_ARGS(&prms, &linkupEventInfo);
+            ENET_IOCTL(hEnet, selfCoreId, ENET_PER_IOCTL_HANDLE_EXTPHY_LINKUP_EVENT, &prms, status);
+        }
+        else
+        {
+            EnetAppUtils_print("Link is not currently up. Ignore this msg");
+            status = ENET_SOK;
+        }
+    }
+    else
+    {
+        ENET_IOCTL_SET_IN_ARGS(&prms, &macPort);
+        ENET_IOCTL(hEnet, selfCoreId, ENET_PER_IOCTL_HANDLE_EXTPHY_LINKDOWN_EVENT, &prms, status);
+    }
+    EnetAppUtils_assert(status == ENET_SOK);
+}
+
+int32_t EnetApp_mdioLinkIntHandlerTask(Enet_Type port2EnetType[ENET_SYSCFG_MAX_MAC_PORTS], uint32_t port2InstId[ENET_SYSCFG_MAX_MAC_PORTS])
+{
+    TaskP_Params tskParams;
+    int32_t status;
+
+    EnetApp_initPhyLinkHandlerCtx(&gMdioLinkEventCtx, port2EnetType, port2InstId);
+    /* Initialize the taskperiodicTick params. Set the task priority higher than the
+     * default priority (1) */
+    TaskP_Params_init(&tskParams);
+    tskParams.priority       = ENETAPP_MDIOLINKINT_HANDLER_TASK_PRIORITY;
+    tskParams.stack          = &gMdioLinkEventCtx.appMdioLinkIntHandlerTaskStack[0];
+    tskParams.stackSize      = sizeof(gMdioLinkEventCtx.appMdioLinkIntHandlerTaskStack);
+    tskParams.args           = &gMdioLinkEventCtx;
+    tskParams.name           = "EnetApp_MdioLinkIntHandlerTask";
+    tskParams.taskMain       =  &EnetApp_mdioLinkIntHandler;
+
+    status = TaskP_construct(&gMdioLinkEventCtx.taskMdioLinkIntHandlerObj, &tskParams);
+    EnetAppUtils_assert(status == SystemP_SUCCESS);
+
+    return status;
+
+}
+
+void EnetApp_mdioLinkChangeISR(Icssg_MdioLinkStateChangeInfo *info,
+                               void *appArg)
+{
+    EnetAppPhyLinkEventCtx *linkIntCtx = (EnetAppPhyLinkEventCtx *)appArg;
+    QueueP_Elem *qelem;
+    EnetAppPhyLinkEventInfoMsg *infoMsg;
+
+    linkIntCtx->mdioLinkChangeIsrCount++;
+    qelem = QueueP_get(linkIntCtx->hFreeMsgQ);
+    EnetAppUtils_assert(qelem != NULL);
+    infoMsg = container_of(qelem, EnetAppPhyLinkEventInfoMsg, elem);
+    infoMsg->linkStateChangeInfo = *info;
+    infoMsg->mdioLinkStateChangeCbArg = appArg;
+    QueueP_put(linkIntCtx->hProcessMsgQ, &infoMsg->elem);
+    SemaphoreP_post(&linkIntCtx->linkIntSem);
+}
+
+static void EnetApp_initMdioLinkIntCfg(Enet_Type enetType, uint32_t instId, Icssg_Cfg *icssgCfg)
+{
+#if (ENET_SYSCFG_ENABLE_MDIO_MANUALMODE == 1U)
+    icssgCfg->mdioLinkIntCfg.mdioLinkStateChangeCb     = NULL;
+    icssgCfg->mdioLinkIntCfg.mdioLinkStateChangeCbArg  = NULL;
+#else
+    /*! MDIO Link state change callback function pointer */
+    icssgCfg->mdioLinkIntCfg.mdioLinkStateChangeCb = EnetApp_mdioLinkChangeISR;
+
+    /*! Application data to be passed to the MDIO link state change callback */
+    icssgCfg->mdioLinkIntCfg.mdioLinkStateChangeCbArg  = &gMdioLinkEventCtx;
+#endif
+}
+
+#if (ENET_SYSCFG_ENABLE_MDIO_MANUALMODE == 1U)
+
+static void EnetApp_phyRegPollHandler(void* appHandle)
+{
+    EnetAppPhyLinkEventCtx *linkIntCtx  = (EnetAppPhyLinkEventCtx *)appHandle;
+    SemaphoreP_Object *pTimerSem        =  &linkIntCtx->linkIntSem;
+
+    while (true)
+    {
+        // phyStatus
+        SemaphoreP_pend(pTimerSem, SystemP_WAIT_FOREVER);
+        const uint32_t pollEnablePhyAddressMask = linkIntCtx->phyPollState.pollEnablePhyAddMask;
+
+        for (uint32_t macPort = 0; macPort < ENET_SYSCFG_MAX_MAC_PORTS; macPort++)
+        {
+            const EnetExtPhy_Handle hPhy = EnetApp_getExtPhyHandle(macPort);
+            if (hPhy == NULL)
+            {
+                continue;
+            }
+            const uint32_t phyAddress = hPhy->phyCfg.phyAddr;
+
+            const uint32_t phyaddressMask = (1 << phyAddress);
+            if (pollEnablePhyAddressMask & phyaddressMask)
+            {
+                const bool isLinked = EnetExtPhy_isLinked(hPhy);
+
+                if ((isLinked << phyAddress) ^ (linkIntCtx->phyPollState.linkStatusPhyAddMask & phyaddressMask))
+                {
+                    // fall here if link status has changed
+                    if (isLinked)
+                    {
+                        linkIntCtx->phyPollState.linkStatusPhyAddMask |= phyaddressMask;
+                    }
+                    else
+                    {
+                        linkIntCtx->phyPollState.linkStatusPhyAddMask &= (~phyaddressMask);
+                    }
+
+                    Icssg_MdioLinkStateChangeInfo info = {
+                                      .phyAddr      = phyAddress,
+                                      .aliveChanged = false,
+                                      .isAlive      = isLinked,
+                                      .linkChanged  = true,
+                                      .isLinked     = isLinked
+                                      };
+
+                    Enet_Handle hEnet = Enet_getHandle(linkIntCtx->port2EnetType[macPort], linkIntCtx->port2InstId[macPort]);
+                    EnetApp_handleLinkChangeEvent(hEnet, &info);
+
+                }
+            } /* if (pollEnablePhyAddressMask & phyaddressMask)*/
+        } /* for loop*/
+    }
+
+    TaskP_destruct(&linkIntCtx->taskMdioLinkIntHandlerObj);
+    TaskP_exit();
+}
+
+
+static void EnetApp_phyRegPollTimerCb(ClockP_Object *clkInst, void * arg)
+{
+    SemaphoreP_Object * pTimerSem = (SemaphoreP_Object *)arg;
+
+    /* Tick! */
+    SemaphoreP_post(pTimerSem);
+}
+
+void EnetApp_enablePhyLinkPollingMask(const uint32_t phyEnableMask)
+{
+    gMdioLinkEventCtx.phyPollState.pollEnablePhyAddMask = phyEnableMask;
+}
+
+int32_t EnetApp_createPhyRegisterPollingTask(const uint32_t pollingPeriod_ms,
+                                             const bool doStartimmediately,
+                                             Enet_Type port2EnetType[ENET_SYSCFG_MAX_MAC_PORTS],
+                                             uint32_t port2InstId[ENET_SYSCFG_MAX_MAC_PORTS])
+{
+    const uint32_t pollingPeriodTicks = ClockP_usecToTicks((ENETPHY_FSM_TICK_PERIOD_MS)*pollingPeriod_ms);  // Set timer expiry time in OS ticks
+
+    EnetApp_initPhyLinkHandlerCtx(&gMdioLinkEventCtx, port2EnetType, port2InstId);
+    EnetAppUtils_assert(SystemP_SUCCESS == SemaphoreP_constructCounting(&(gMdioLinkEventCtx.linkIntSem), 0, 128));
+    ClockP_Params clkParams;
+    ClockP_Params_init(&clkParams);
+    clkParams.start     = doStartimmediately;
+    clkParams.timeout   = pollingPeriodTicks;
+    clkParams.period    = pollingPeriodTicks;
+    clkParams.args      = &(gMdioLinkEventCtx.linkIntSem);
+    clkParams.callback  = &EnetApp_phyRegPollTimerCb;
+
+    /* Creating timer and setting timer callback function*/
+    const int32_t timerStatus = ClockP_construct(&(gMdioLinkEventCtx.phyRegPollTimerObj), &clkParams);
+    EnetAppUtils_assert(timerStatus == SystemP_SUCCESS);
+    if (timerStatus != SystemP_SUCCESS)
+    {
+        EnetAppUtils_print("failed to PHY polling clock\r\n");
+        return timerStatus;
+    }
+
+    /* Initialize the taskperiodicTick params. Set the task priority higher than the
+     * default priority (1) */
+    TaskP_Params tskParams;
+    TaskP_Params_init(&tskParams);
+    tskParams.priority       = ENETAPP_MDIOLINKINT_HANDLER_TASK_PRIORITY;
+    tskParams.stack          = &(gMdioLinkEventCtx.appMdioLinkIntHandlerTaskStack[0]);
+    tskParams.stackSize      = sizeof(gMdioLinkEventCtx.appMdioLinkIntHandlerTaskStack);
+    tskParams.args           = &gMdioLinkEventCtx;
+    tskParams.name           = "EnetApp_PhyRegPollTask";
+    tskParams.taskMain       = &EnetApp_phyRegPollHandler;
+
+    const int32_t taskStatus = TaskP_construct(&gMdioLinkEventCtx.taskMdioLinkIntHandlerObj, &tskParams);
+    EnetAppUtils_assert(taskStatus == SystemP_SUCCESS);
+
+    return (timerStatus | taskStatus);
+}
+#endif /*#if (ENET_SYSCFG_ENABLE_MDIO_MANUALMODE == 1U) */
+
+#endif
+
+static void EnetApp_updateMdioLinkIntCfg(Enet_Type enetType, uint32_t instId, Icssg_mdioLinkIntCfg *mdioLinkIntCfg)
+{
+    /*! INTC Module mapping data passed by application for configuring PRU to R5F interrupts */
+#if (ENET_SYSCFG_ICSSG0_ENABLED == 1)
+    mdioLinkIntCfg->prussIntcInitData =  &icss0_intc_initdata;
+#endif
+#if (ENET_SYSCFG_ICSSG1_ENABLED == 1)
+    mdioLinkIntCfg->prussIntcInitData =  &icss1_intc_initdata;
+#endif
+    mdioLinkIntCfg->coreIntrNum = 254;
+    mdioLinkIntCfg->pruEvtNum[0] = MII_LINK0_EVENT;
+    mdioLinkIntCfg->pruEvtNum[1] = MII_LINK1_EVENT;
+    mdioLinkIntCfg->isPulseIntr = 0;
+    mdioLinkIntCfg->intrPrio = 15;
+}
+
+void EnetApp_updateIcssgInitCfg(Enet_Type enetType, uint32_t instId, Icssg_Cfg *icssgCfg)
+{
+#if (ENET_SYSCFG_ENABLE_MDIO_MANUALMODE == 1U)
+    icssgCfg->mdioLinkIntCfg.mdioLinkStateChangeCb = NULL;
+    icssgCfg->mdioLinkIntCfg.mdioLinkStateChangeCbArg  = NULL;
+#else
+    #if (ENET_SYSCFG_ENABLE_EXTPHY == 1U)
+        EnetApp_initMdioLinkIntCfg(enetType, instId, icssgCfg);
+    #else
+        icssgCfg->mdioLinkIntCfg.mdioLinkStateChangeCb = &EnetApp_mdioLinkStatusChange;
+        icssgCfg->mdioLinkIntCfg.mdioLinkStateChangeCbArg  = NULL;
+    #endif
+    EnetApp_updateMdioLinkIntCfg(enetType, instId, &icssgCfg->mdioLinkIntCfg);
+#endif
+}
+
+#if (ENET_SYSCFG_ENABLE_EXTPHY == 0U)
+static void EnetApp_mdioLinkStatusChange(Icssg_MdioLinkStateChangeInfo *info,
+                                         void *appArg)
+{
+    EnetAppUtils_print("Link Status Changed. PHY: 0x%x, state: %s\r\n",
+            info->phyAddr,
+            info->isLinked? "up" : "down");
+}
+#endif

--- a/examples/netxduo/enet_netxduo_icssg_iperf/netxduo_icssg.c
+++ b/examples/netxduo/enet_netxduo_icssg_iperf/netxduo_icssg.c
@@ -55,45 +55,51 @@
 #include <include/per/icssg.h>
 #include <priv/per/icssg_priv.h>
 
-
 #if (NETXDUO_COUNT > 1u)
 #error "This example does not support more than one Netx instance."
 #endif
 
-#if (NETXDUO_IF_COUNT > 1u)
-#error "This example does not support more than one interface."
-#endif
 
 /* ========================================================================== */
 /*                           Macros & Typedefs                                */
 /* ========================================================================== */
 
-#define PACKET_SIZE     1536
-#define POOL_SIZE      ((sizeof(NX_PACKET) + PACKET_SIZE) * (ENET_SYSCFG_TOTAL_NUM_RX_PKT + ENET_SYSCFG_TOTAL_NUM_TX_PKT))
+#define PACKET_SIZE                    (1536u)
+#define IPERF_POOL_SIZE                ((sizeof(NX_PACKET) + PACKET_SIZE) * (ENET_SYSCFG_TOTAL_NUM_TX_PKT / 2))
+#define INTERNAL_POOL_SIZE             ((sizeof(NX_PACKET) + PACKET_SIZE) * (ENET_SYSCFG_TOTAL_NUM_TX_PKT / 2 + ENET_SYSCFG_TOTAL_NUM_RX_PKT))
 
 #define IP_THREAD_STACK_SIZE        8192u
 #define IP_ARP_THREAD_STACK_SIZE    8192u
+#define HTTP_STACK_SIZE                (8192u)
+#define IPERF_STACK_SIZE               (8192u)
 
 
 /* ========================================================================== */
 /*                            Global Variables                                */
 /* ========================================================================== */
 
-static uint8_t gIpThreadStack[IP_THREAD_STACK_SIZE]__attribute__((aligned(ENET_UTILS_CACHELINE_SIZE)));
-static uint8_t gIpArpThreadStack[IP_ARP_THREAD_STACK_SIZE]__attribute__((aligned(ENET_UTILS_CACHELINE_SIZE)));
 
-static uint8_t gPoolMem[POOL_SIZE]__attribute__ ((aligned(ENETDMA_CACHELINE_ALIGNMENT), section(".bss:ENET_DMA_PKT_MEMPOOL")));
+static uint8_t gIpThreadStack[IP_THREAD_STACK_SIZE]__attribute__((aligned(ENETDMA_CACHELINE_ALIGNMENT)));
+static uint8_t gIpArpThreadStack[IP_ARP_THREAD_STACK_SIZE]__attribute__((aligned(ENETDMA_CACHELINE_ALIGNMENT)));
+static uint8_t gHttpThreadStack[HTTP_STACK_SIZE]__attribute__((aligned(ENET_UTILS_CACHELINE_SIZE)));
+static uint8_t gIperfThreadStack[IPERF_STACK_SIZE]__attribute__((aligned(ENET_UTILS_CACHELINE_SIZE)));
+static uint8_t gInternalPoolMem[INTERNAL_POOL_SIZE]__attribute__ ((aligned(ENETDMA_CACHELINE_ALIGNMENT), section(".bss:ENET_DMA_PKT_MEMPOOL")));
+static uint8_t gIperfPoolMem[IPERF_POOL_SIZE]__attribute__ ((aligned(ENETDMA_CACHELINE_ALIGNMENT), section(".bss:ENET_DMA_PKT_MEMPOOL")));
 
-static NX_PACKET_POOL gPacketPool;
+static NX_PACKET_POOL gInternalPacketPool;
+static NX_PACKET_POOL gIperfPacketPool;
 static NX_IP gIp;
 static NX_DHCP gDhcpClient;
 
 
 /* ========================================================================== */
-/*                          Function Prototypes                               */
+/*                          Function Declarations                             */
 /* ========================================================================== */
 
 static int32_t EnetApp_setMacAddress(const Enet_Type enetType, uint32_t instId, Enet_MacPort macPort, uint8_t macAddr[ENET_MAC_ADDR_LEN]);
+
+extern  VOID nx_iperf_entry(NX_PACKET_POOL *pool_ptr, NX_IP *ip_ptr, UCHAR* http_stack, ULONG http_stack_size, UCHAR *iperf_stack, ULONG iperf_stack_size);
+
 
 
 /* ========================================================================== */
@@ -105,81 +111,136 @@ int netxduo_icssg_main(ULONG arg)
     Enet_Type enetType;
     uint32_t instId;
     Enet_MacPort macPort;
+    const char *pIfName;
+    size_t ifIx;
+    size_t dfltIfIx;
     ULONG actual_status;
-    ULONG netMask;
     ULONG ipAddr;
+    ULONG netMask;
+    uint32_t ifRxChCnt;
+    uint32_t ifTxChCnt;
+    uint32_t allRxChCnt;
+    uint32_t allTxChCnt;
+    const uint32_t *allRxChIds;
+    const uint32_t *allTxChIds;
+    nx_enet_drv_rx_ch_hndl_t ifRxChs[ENET_SYSCFG_RX_FLOWS_NUM];
+    nx_enet_drv_tx_ch_hndl_t ifTxChs[ENET_SYSCFG_TX_CHANNELS_NUM];
+    nx_enet_drv_rx_ch_hndl_t allRxChs[ENET_SYSCFG_RX_FLOWS_NUM];
+    nx_enet_drv_tx_ch_hndl_t allTxChs[ENET_SYSCFG_TX_CHANNELS_NUM];
+    uint32_t ifRxChIds[ENET_SYSCFG_RX_FLOWS_NUM];
+    uint32_t ifTxChIds[ENET_SYSCFG_TX_CHANNELS_NUM];
     EnetApp_GetMacAddrOutArgs outArgs;
-    uint32_t rxChCnt;
-    uint32_t txChCnt;
-    const uint32_t *rxChIds;
-    const uint32_t *txChIds;
-    nx_enet_drv_rx_ch_hndl_t rxChs[ENET_SYSCFG_RX_FLOWS_NUM];
-    nx_enet_drv_tx_ch_hndl_t txChs[ENET_SYSCFG_TX_CHANNELS_NUM];
     int32_t status = ENET_SOK;
 
     Drivers_open();
     Board_driversOpen();
 
-    DebugP_log("==============================\r\n");
-    DebugP_log("   NETXDUO ICSSG SWITCH MODE  \r\n");
-    DebugP_log("==============================\r\n");
-
-
-    EnetApp_getEnetInstInfo(CONFIG_ENET_ICSS0, &enetType, &instId);
-
-    EnetAppUtils_enableClocks(enetType, instId);
+    DebugP_log("==========================\r\n");
+    DebugP_log("    NETXDUO ICSSG MAC     \r\n");
+    DebugP_log("==========================\r\n");
 
     EnetApp_driverInit();
-    status = EnetApp_driverOpen(enetType, instId);
-    DebugP_assert(status == ENET_SOK);
+
+    /* Read MAC Port details and enable clock for each ENET instance */
+    for (size_t k = 0u; k < ENET_SYSCFG_MAX_ENET_INSTANCES; k++) {
+
+        EnetApp_getEnetInstInfo(CONFIG_ENET_ICSS0 + k, &enetType, &instId);
+
+        EnetAppUtils_enableClocks(enetType, instId);
+
+        status = EnetApp_driverOpen(enetType, instId);
+        DebugP_assert(status == ENET_SOK);
+    }
 
 
     /* Initialize the NetX system.  */
     nx_system_initialize();
 
     /* Create a packet pool.  */
-    status = nx_packet_pool_create(&gPacketPool, "NetX Main Packet Pool", PACKET_SIZE, &gPoolMem[0], POOL_SIZE);
+    status = nx_packet_pool_create(&gInternalPacketPool, "NetX Main Packet Pool", PACKET_SIZE, &gInternalPoolMem[0], INTERNAL_POOL_SIZE);
+    EnetAppUtils_assert(status == NX_SUCCESS);
+
+    /* Create Iperf packet pool.  */
+    status = nx_packet_pool_create(&gIperfPacketPool, "Iperf packet pool", PACKET_SIZE, &gIperfPoolMem[0], IPERF_POOL_SIZE);
     EnetAppUtils_assert(status == NX_SUCCESS);
 
 
     /* Allocate NetX Rx channel and corresponding buffers. */
-    NetxEnetApp_getAllRxChIDs(&rxChIds, &rxChCnt);
-    for(size_t k = 0u; k < rxChCnt; k++) {
+    NetxEnetApp_getAllRxChIDs(&allRxChIds, &allRxChCnt);
+    for(size_t k = 0u; k < allRxChCnt; k++) {
 
         EnetApp_GetDmaHandleInArgs inArgs = {0};
         EnetApp_GetRxDmaHandleOutArgs outArgs;
 
-        EnetApp_getRxDmaHandle(rxChIds[k], &inArgs, &outArgs);
+        EnetApp_getRxDmaHandle(allRxChIds[k], &inArgs, &outArgs);
 
         EnetAppUtils_assert(outArgs.hRxCh != NULL);
-        NetxEnetDriver_allocRxCh(outArgs.hRxCh, outArgs.maxNumRxPkts, &gPacketPool, &rxChs[k]);
+        NetxEnetDriver_allocRxCh(outArgs.hRxCh, outArgs.maxNumRxPkts, &gInternalPacketPool, &allRxChs[k]);
     }
 
     /* Allocate NetX Tx channel and corresponding buffers. */
-    NetxEnetApp_getAllTxChIDs(&txChIds, &txChCnt);
-    for (size_t k = 0u; k < txChCnt; k++) {
+    NetxEnetApp_getAllTxChIDs(&allTxChIds, &allTxChCnt);
+    for (size_t k = 0u; k < allTxChCnt; k++) {
 
         EnetApp_GetDmaHandleInArgs inArgs = {0};
         EnetApp_GetTxDmaHandleOutArgs outArgs;
 
-        EnetApp_getTxDmaHandle(txChIds[k], &inArgs, &outArgs);
+        EnetApp_getTxDmaHandle(allTxChIds[k], &inArgs, &outArgs);
 
         EnetAppUtils_assert(outArgs.hTxCh != NULL);
-        NetxEnetDriver_allocTxCh(outArgs.hTxCh, outArgs.maxNumTxPkts, &txChs[k]);
+        NetxEnetDriver_allocTxCh(outArgs.hTxCh, outArgs.maxNumTxPkts, &allTxChs[k]);
     }
 
-    macPort = NetxEnetApp_getMacPort(0, 0);
-    EnetApp_getMacAddress(rxChIds[0], &outArgs);
 
-    EnetApp_setMacAddress(enetType, instId, macPort, &outArgs.macAddr[0][0]);
+    /* Allocate network interfaces and bind to corresponding DMA channels. */
+    dfltIfIx = NetxEnetApp_getDefaultIfIdx();
+    for (size_t ifCtr = 0u; ifCtr < NETXDUO_IF_COUNT; ifCtr++) {
 
-    NetxEnetDriver_allocIf("PRI", ENET_MAC_PORT_INV, &outArgs.macAddr[0][0], &rxChs[0], rxChCnt, &txChs[0], txChCnt);
+        /* From NetX standpoint, the default interface is always the primary (PRI) interface. */
+        ifIx = ifCtr == 0u ? dfltIfIx : (dfltIfIx == 0) ? 1 : 0;
+        pIfName = ifCtr == 0u ? "PRI" : "SEC";
+
+        NetxEnetApp_getRxChIDs(0, ifIx, &ifRxChCnt, &ifRxChIds[0]);
+        for (size_t n = 0u; n < ifRxChCnt; n++) {
+            ifRxChs[n] = NULL;
+            for (size_t k = 0u; k < allRxChCnt; k++) {
+                if (allRxChIds[k] == ifRxChIds[n]) {
+                    ifRxChs[n] = allRxChs[k];
+                    break;
+                }
+            }
+            EnetAppUtils_assert(ifRxChs[n] != NULL);
+        }
+
+        NetxEnetApp_getTxChIDs(0, ifIx, &ifTxChCnt, &ifTxChIds[0]);
+        for (size_t n = 0u; n < ifTxChCnt; n++) {
+            ifTxChs[n] = NULL;
+            for (size_t k = 0u; k < allTxChCnt; k++) {
+                if (allTxChIds[k] == ifTxChIds[n]) {
+                    ifTxChs[n] = allTxChs[k];
+                    break;
+                }
+            }
+            EnetAppUtils_assert(ifTxChs[n] != NULL);
+        }
+
+        macPort = NetxEnetApp_getMacPort(0, ifIx);
+        EnetApp_getMacAddress(ifRxChIds[0], &outArgs);
+
+        NetxEnetApp_getEnetTypeAndIdFromIfIdx(0, ifIx, &enetType, &instId);
+        EnetApp_setMacAddress(enetType, instId, macPort, &outArgs.macAddr[0][0]);
+        NetxEnetDriver_allocIf(pIfName, macPort, &outArgs.macAddr[0][0], &ifRxChs[0], ifRxChCnt, &ifTxChs[0], ifTxChCnt);
+    }
 
 
     /* Create an IP instance.  */
-    status = nx_ip_create(&gIp, "NetX IP Instance 0", IP_ADDRESS(0, 0, 0, 0), 0xFFFFFF00UL, &gPacketPool, _nx_enet_driver, (void *)&gIpThreadStack[0], IP_THREAD_STACK_SIZE, 1);
+    status = nx_ip_create(&gIp, "NetX IP Instance 0", IP_ADDRESS(0, 0, 0, 0), 0xFFFFFF00UL, &gInternalPacketPool, _nx_enet_driver, (void *)&gIpThreadStack[0], IP_THREAD_STACK_SIZE, 1);
     EnetAppUtils_assert(status == NX_SUCCESS);
 
+#if (NETXDUO_IF_COUNT > 1u)
+    status = nx_ip_interface_attach(&gIp, "SEC", IP_ADDRESS(0, 0, 0, 0), 0xFFFFFF00UL, _nx_enet_driver);
+    EnetAppUtils_assert(status == NX_SUCCESS);
+#endif
 
     /* Enable ARP */
     status = nx_arp_enable(&gIp, (void *)&gIpArpThreadStack[0], IP_ARP_THREAD_STACK_SIZE);
@@ -191,6 +252,10 @@ int netxduo_icssg_main(ULONG arg)
 
     /* Enable UDP. */
     status = nx_udp_enable(&gIp);
+    EnetAppUtils_assert(status == NX_SUCCESS);
+
+    /* Enable TCP. */
+    status = nx_tcp_enable(&gIp);
     EnetAppUtils_assert(status == NX_SUCCESS);
 
 
@@ -222,6 +287,11 @@ int netxduo_icssg_main(ULONG arg)
     EnetAppUtils_assert(status == NX_SUCCESS);
 
     DebugP_log("Local Interface IP is: %lu.%lu.%lu.%lu\n", ((ipAddr >> 24u) & 0xFF), ((ipAddr >> 16u) & 0xFF), ((ipAddr >> 8u) & 0xFF), (ipAddr & 0xFF));
+
+
+    /* Call entry function to start iperf test.  */
+    nx_iperf_entry(&gIperfPacketPool, &gIp, gHttpThreadStack, HTTP_STACK_SIZE, gIperfThreadStack, IPERF_STACK_SIZE);
+
 
     while (1) {
 
@@ -255,7 +325,7 @@ static int32_t EnetApp_setMacAddress(const Enet_Type enetType, uint32_t instId, 
         if (status != ENET_SOK)
         {
             EnetAppUtils_print(
-                    "Lwip2Enet_setMacAddress() failed ICSSG_MACPORT_IOCTL_ADD_INTERFACE_MACADDR: %d\r\n",
+                    "EnetApp_setMacAddress() failed ICSSG_MACPORT_IOCTL_ADD_INTERFACE_MACADDR: %d\r\n",
                     status);
         }
         EnetAppUtils_assert(status == ENET_SOK);
@@ -274,7 +344,7 @@ static int32_t EnetApp_setMacAddress(const Enet_Type enetType, uint32_t instId, 
             if (status != ENET_SOK)
             {
                 EnetAppUtils_print(
-                        "EnetAppUtils_addHostPortEntry() failed ICSSG_HOSTPORT_IOCTL_SET_MACADDR: %d\r\n",
+                        "EnetApp_setMacAddress() failed ICSSG_HOSTPORT_IOCTL_SET_MACADDR: %d\r\n",
                         status);
             }
             EnetAppUtils_assert(status == ENET_SOK);


### PR DESCRIPTION
- add icssg iperf example project on evm and launchpad.
- add icssg gptp example project on evm and launchpad.
- fix erroneous mac port configuration in cpsw and icssg switch mode examples.
- fix unused variable in icssg gptp example.
- fix unused variable in cpsw switch example.
- include missing linker script for some NETX examples.